### PR TITLE
middleware init with optional kwarg.

### DIFF
--- a/easyaudit/middleware/easyaudit.py
+++ b/easyaudit/middleware/easyaudit.py
@@ -22,7 +22,7 @@ def get_current_user():
 
 class EasyAuditMiddleware(MiddlewareMixin):
     """Makes request available to this app signals."""
-    def __init__(self, get_response):
+    def __init__(self, get_response=None):
         self.get_response = get_response
 
     def __call__(self, request):


### PR DESCRIPTION
middleware init with optional kwarg.

I was getting a startup error because the `__init__` apparently wants no arguments. The mixin class's `__init__` had it as a default variable, so I did the same (I could have just not subclassed the init of course).