### PR TITLE
Log `m2m_changed` signal

### DIFF
--- a/easyaudit/models.py
+++ b/easyaudit/models.py
@@ -8,10 +8,15 @@ class CRUDEvent(models.Model):
     CREATE = 1
     UPDATE = 2
     DELETE = 3
+    M2M_CHANGE = 4
+    M2M_CHANGE_REV = 5
+
     TYPES = (
         (CREATE, 'Create'),
         (UPDATE, 'Update'),
         (DELETE, 'Delete'),
+        (M2M_CHANGE, 'Many-to-Many Change'),
+        (M2M_CHANGE_REV, 'Reverse Many-to-Many Change'),
     )
 
     event_type = models.SmallIntegerField(choices=TYPES)

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -94,6 +94,16 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
             event_type = CRUDEvent.M2M_CHANGE_REV
         else:
             event_type = CRUDEvent.M2M_CHANGE
+
+        # user
+        try:
+            user = get_current_user()
+        except:
+            user = None
+
+        if isinstance(user, AnonymousUser):
+            user = None
+
     except Exception:
         logger.exception('easy audit had an m2m-changed exception.')
     pass

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -85,6 +85,9 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
 def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwargs):
 
     try:
+        if not should_audit(instance):
+            return False
+
         if reverse:
             event_type = CRUDEvent.M2M_CHANGE_REV
         else:

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -82,6 +82,10 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
         logger.exception('easy audit had a post-save exception.')
 
 
+def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwargs):
+    pass
+
+
 def post_delete(sender, instance, using, **kwargs):
     """https://docs.djangoproject.com/es/1.10/ref/signals/#post-delete"""
     try:
@@ -143,6 +147,7 @@ def user_login_failed(sender, credentials, **kwargs):
 
 
 models_signals.post_save.connect(post_save, dispatch_uid='easy_audit_signals_post_save')
+models_signals.m2m_changed.connect(m2m_changed, dispatch_uid='easy_audit_signals_m2m_changed')
 models_signals.post_delete.connect(post_delete, dispatch_uid='easy_audit_signals_post_delete')
 
 if WATCH_LOGIN_EVENTS:

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -104,6 +104,18 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
         if isinstance(user, AnonymousUser):
             user = None
 
+        crud_event = CRUDEvent.objects.create(
+            event_type=event_type,
+            object_repr=str(instance),
+            object_json_repr=object_json_repr,
+            content_type=ContentType.objects.get_for_model(instance),
+            object_id=instance.id,
+            user=user,
+            datetime=timezone.now(),
+            user_pk_as_string=str(user.pk) if user else user
+        )
+
+        crud_event.save()
     except Exception:
         logger.exception('easy audit had an m2m-changed exception.')
     pass

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -83,6 +83,14 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
 
 
 def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwargs):
+
+    try:
+        if reverse:
+            event_type = CRUDEvent.M2M_CHANGE_REV
+        else:
+            event_type = CRUDEvent.M2M_CHANGE
+    except Exception:
+        logger.exception('easy audit had an m2m-changed exception.')
     pass
 
 

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -88,6 +88,8 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
         if not should_audit(instance):
             return False
 
+        object_json_repr = serializers.serialize("json", [instance])
+
         if reverse:
             event_type = CRUDEvent.M2M_CHANGE_REV
         else:


### PR DESCRIPTION
This PR updates django-easy-audit to log m2m-changed signals. I'm still fixing the following two issues:

1) Each M2M update is recorded twice, because M2M changes send two signals (`pre_add`/`post_add` for additions and `pre_remove`/`post_remove` for deletions).

   * I am going to filter out half of the signals. I would prefer to keep the pre-save actions (`pre_add` and `pre_remove`), but to be consistent with easyaudit's other signals, I am going to keep the post-save ones (`post_add` and `post_remove`).

2) Reverse M2M updates do not include the M2M change in the audit log.

   * Reverse M2M updates (e.g. if the `Business` model has a ManyToManyField connected to `User`, a reverse add would be `some_user.business_set.add(some_business)`, as opposed to `some_business.users.add(some_user)`) do not include the M2M field, because the M2M field is not actually present on that model. I'm not sure how to resolve this; need to think about it more.