### PR TITLE
Log reverse M2M changes

### DIFF
--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -124,6 +124,7 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
 
             tmp_repr[0]['m2m_rev_model'] = force_text(model._meta)
             tmp_repr[0]['m2m_rev_pks'] = related_ids
+            tmp_repr[0]['m2m_rev_action'] = action
             object_json_repr = json.dumps(tmp_repr)
         else:
             event_type = CRUDEvent.M2M_CHANGE

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -118,7 +118,6 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
         crud_event.save()
     except Exception:
         logger.exception('easy audit had an m2m-changed exception.')
-    pass
 
 
 def post_delete(sender, instance, using, **kwargs):

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -88,6 +88,9 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
         if not should_audit(instance):
             return False
 
+        if action not in ("post_add", "post_remove", "post_clear"):
+            return False
+
         object_json_repr = serializers.serialize("json", [instance])
 
         if reverse:

--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -83,7 +83,7 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
 
 
 def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwargs):
-
+    """https://docs.djangoproject.com/es/1.10/ref/signals/#m2m-changed"""
     try:
         if not should_audit(instance):
             return False


### PR DESCRIPTION
This PR addresses the follow-up items from #20. @soynatan, let me know if you have questions or concerns. Thanks! 

## Reverse M2M Logging
Most of the new code is for logging related objects' keys after reverse M2M changes. Prior to these changes, these fields were not serialized in `CRUDEvent.object_json_repr` because they are not stored in a concrete model field.

The changes add three new fields to `object_json_repr` for reverse M2M information:

   * `m2m_rev_action` - the M2M action, i.e. `post_add`, `post_remove`, or `post_clear`
   * `m2m_rev_model` - the name of the related model whose instances have been added or removed
   * `m2m_rev_pks` - the primary keys of all related model instances connected to this object after the action was performed

The new `m2m_rev_*` fields will be ignored by Django's deserializer because they do not represent actual object fields.

### Example
Imagine having two models, `Project` and `Employee`. Each project can be staffed by multiple employees, and each employee can work on multiple projects. There is a `ManyToMany` field on `Project` to capture this.

If employee 8 is already working on project 33, and I assign them to project 44 by calling `employee_eight.project_set.add(44)`, then the `CRUDEvent.object_json_repr` that gets logged will look like this:

```
{
    "pk": 8,
    "model": "business.employee",
    "fields": {
        "first_name": "John"
        "last_name": "Smith"
        "email": "John@example.com",
        "date_joined": "2016-11-29T21:51:18Z"
    },
    "m2m_rev_action": "post_add",                # new
    "m2m_rev_model": "business.project",         # new
    "m2m_rev_pks": [33, 44]                      # new
}
```

### Shortcomings

* Works by deserializing `object_json_repr`, adding the new fields, then reserializing it. This may cause noticeable performance reductions if you perform many reverse M2M updates and/or have large models.
* Doesn't tell you which specific keys were added or removed, only gives you a snapshot of what the keys look like after the operation is complete.
* Doesn't handle natural foreign keys.

## Other Changes

This PR also prevents double-logging M2M events by filtering out actions other than `post_add`, `post_remove`, and `post_clear`.