### PR TITLE
Removed redundant save() calls (create() includes implicit save())

### DIFF
--- a/easyaudit/signals.py
+++ b/easyaudit/signals.py
@@ -147,8 +147,6 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
             datetime=timezone.now(),
             user_pk_as_string=str(user.pk) if user else user
         )
-
-        crud_event.save()
     except Exception:
         logger.exception('easy audit had an m2m-changed exception.')
 
@@ -181,8 +179,6 @@ def post_delete(sender, instance, using, **kwargs):
             datetime=timezone.now(),
             user_pk_as_string=str(user.pk) if user else user
         )
-
-        crud_event.save()
     except Exception:
         logger.exception('easy audit had a post-delete exception.')
 


### PR DESCRIPTION
Hi @soynatan! Thanks for your work on this library. We were on the hunt for a django auditing lib, and yours was just the thing!

After integrating, we noticed when running our tests that there were more audit queries than we expected. A little digging led us to find two `save()` calls in `signals.py` that look redundant with the `create()` calls above them. I'm a bit new to django development, so I checked the relevant docs to be sure:
https://docs.djangoproject.com/en/1.11/ref/models/querysets/#create

This PR just removes the redundant `save()` calls, which should be a nice performance boost for those (like us!) using the library heavily in their apps. 

I ran the tests after making this change, and also did some live tests in our app (not referenced in this PR, naturally), and things still seem to be working.

Let me know if you have any thoughts on this PR. Happy to make changes if helpful!