### PR TITLE
on session get, .get() on user id.

### DIFF
--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -37,7 +37,7 @@ def request_started_handler(sender, environ, **kwargs):
                 session = None
 
             if session:
-                user_id = session.get_decoded()['_auth_user_id']
+                user_id = session.get_decoded().get('_auth_user_id')
                 try:
                     user = get_user_model().objects.get(id=user_id)
                 except:


### PR DESCRIPTION
Simple fix for when the session is not used for authentication

I ran into this on my project, because we don't usually use the HTTP session.

It may be worth researching ways to plug in other authentication systems, but that is out of this scope.