### PR TITLE
Make remote IP header configurable for servers behind load balancers

### DIFF
--- a/easyaudit/settings.py
+++ b/easyaudit/settings.py
@@ -28,6 +28,7 @@ def get_model_list(class_list):
 WATCH_AUTH_EVENTS = getattr(settings, 'DJANGO_EASY_AUDIT_WATCH_AUTH_EVENTS', True)
 WATCH_MODEL_EVENTS = getattr(settings, 'DJANGO_EASY_AUDIT_WATCH_MODEL_EVENTS', True)
 WATCH_REQUEST_EVENTS = getattr(settings, 'DJANGO_EASY_AUDIT_WATCH_REQUEST_EVENTS', True)
+REMOTE_ADDR_HEADER = getattr(settings, 'DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER', 'REMOTE_ADDR')
 
 
 # Models which Django Easy Audit will not log.

--- a/easyaudit/signals/auth_signals.py
+++ b/easyaudit/signals/auth_signals.py
@@ -3,7 +3,7 @@ from django.db import transaction
 
 from easyaudit.middleware.easyaudit import get_current_request
 from easyaudit.models import LoginEvent
-from easyaudit.settings import WATCH_AUTH_EVENTS
+from easyaudit.settings import REMOTE_ADDR_HEADER, WATCH_AUTH_EVENTS
 
 def user_logged_in(sender, request, user, **kwargs):
     try:
@@ -11,7 +11,7 @@ def user_logged_in(sender, request, user, **kwargs):
             login_event = LoginEvent.objects.create(login_type=LoginEvent.LOGIN,
                                      username=getattr(user, user.USERNAME_FIELD),
                                      user=user,
-                                     remote_ip=request.META['REMOTE_ADDR'])
+                                     remote_ip=request.META[REMOTE_ADDR_HEADER])
     except:
         pass
 
@@ -22,7 +22,7 @@ def user_logged_out(sender, request, user, **kwargs):
             login_event = LoginEvent.objects.create(login_type=LoginEvent.LOGOUT,
                                                     username=getattr(user, user.USERNAME_FIELD),
                                                     user=user,
-                                                    remote_ip=request.META['REMOTE_ADDR'])
+                                                    remote_ip=request.META[REMOTE_ADDR_HEADER])
     except:
         pass
 
@@ -34,7 +34,7 @@ def user_login_failed(sender, credentials, **kwargs):
             user_model = get_user_model()
             login_event = LoginEvent.objects.create(login_type=LoginEvent.FAILED,
                                                     username=credentials[user_model.USERNAME_FIELD],
-                                                    remote_ip=request.META['REMOTE_ADDR'])
+                                                    remote_ip=request.META[REMOTE_ADDR_HEADER])
     except:
         pass
 

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -6,7 +6,7 @@ from django.utils import six, timezone
 from django.conf import settings
 
 from easyaudit.models import RequestEvent
-from easyaudit.settings import UNREGISTERED_URLS, WATCH_REQUEST_EVENTS
+from easyaudit.settings import REMOTE_ADDR_HEADER, UNREGISTERED_URLS, WATCH_REQUEST_EVENTS
 
 import re
 
@@ -51,7 +51,7 @@ def request_started_handler(sender, environ, **kwargs):
         method=environ['REQUEST_METHOD'],
         query_string=environ['QUERY_STRING'],
         user=user,
-        remote_ip=environ['REMOTE_ADDR'],
+        remote_ip=environ[REMOTE_ADDR_HEADER],
         datetime=timezone.now()
     )
 


### PR DESCRIPTION
This change allows users to configure what header is used for looking up the remote IP of the request. This is useful when a server behind a load balancer needs the IP of the request, and not the IP of the load balancer.