### PR TITLE
Implemented auditing of ONLY REGISTERED_URLS

### DIFF
--- a/easyaudit/settings.py
+++ b/easyaudit/settings.py
@@ -60,6 +60,13 @@ UNREGISTERED_URLS = getattr(settings, 'DJANGO_EASY_AUDIT_UNREGISTERED_URLS_DEFAU
 UNREGISTERED_URLS.extend(getattr(settings, 'DJANGO_EASY_AUDIT_UNREGISTERED_URLS_EXTRA', []))
 
 
+# URLs which Django Easy Audit WILL log.
+# If the following setting is defined in the project,
+# only the listed URLs will be audited, and every other
+# URL will be excluded.
+REGISTERED_URLS = getattr(settings, 'DJANGO_EASY_AUDIT_REGISTERED_URLS', [])
+
+
 # By default all modules are listed in the admin.
 # This can be changed with the following settings.
 ADMIN_SHOW_MODEL_EVENTS = getattr(settings, 'DJANGO_EASY_AUDIT_ADMIN_SHOW_MODEL_EVENTS', True)

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -6,7 +6,7 @@ from django.utils import six, timezone
 from django.conf import settings
 
 from easyaudit.models import RequestEvent
-from easyaudit.settings import REMOTE_ADDR_HEADER, UNREGISTERED_URLS, WATCH_REQUEST_EVENTS
+from easyaudit.settings import REMOTE_ADDR_HEADER, UNREGISTERED_URLS, REGISTERED_URLS, WATCH_REQUEST_EVENTS
 
 import re
 
@@ -17,6 +17,16 @@ def should_log_url(url):
         pattern = re.compile(unregistered_url)
         if pattern.match(url):
             return False
+
+    # only audit URLs listed in REGISTERED_URLS (if it's set)
+    if len(REGISTERED_URLS) > 0:
+        for registered_url in REGISTERED_URLS:
+            pattern = re.compile(registered_url)
+            if pattern.match(url):
+                return True
+        return False
+
+    # all good    
     return True
 
 


### PR DESCRIPTION
I noticed that it was possible to specify a list of models to audit, ignoring all the others. This wasn't possible with url requests so I tried to implement it.

Setting the variable DJANGO_EASY_AUDIT_REGISTERED_URLS as a list of url patterns will allow to choose what url request to audit and ignore all the others.