### PR TITLE
Add a pluggable logging backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Below are some of the settings you may want to use. These should be defined in y
   A list of Django models which will be ignored by Django Easy Audit.
   Use it to prevent logging one or more of your project's models.
   List items can be classes or strings with `app_name.model_name` format.
-
+  
 * `DJANGO_EASY_AUDIT_UNREGISTERED_URLS_EXTRA`
 
   A list of URLs which will be ignored by Django Easy Audit.
@@ -59,6 +59,28 @@ Below are some of the settings you may want to use. These should be defined in y
   will be matched against the URL path.
   [Check our wiki](https://github.com/soynatan/django-easy-audit/wiki/Settings#request-auditing)
   for more details on how to use it.
+  
+* `DJANGO_EASY_AUDIT_LOGGING_BACKEND`
+
+  A pluggable backend option for logging. Defaults to `easyaudit.backends.ModelBackend`.
+  This class expects to have 3 methods: 
+  * `login(self, login_info_dict):`  
+  * `crud(self, crud_info_dict):`  
+  * `request(self, request_info_dict):`
+  
+  each of these methods accept a dictionary containing the info regarding the event.  
+  example overriding:
+  ```python
+    import logging
+    from easyaudit.backends import ModelBackend
+    
+    class AuditKibanaBackend(ModelBackend):
+      logger = logging.getLogger('your-kibana-logger')
+
+        def crud(self, crud_info):
+            self.logger.info(msg='your message', extra=crud_info)
+
+  ```
 
 ## What does it do
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,16 @@ Below are some of the settings you may want to use. These should be defined in y
   example overriding:
   ```python
     import logging
-    from easyaudit.backends import ModelBackend
     
-    class AuditKibanaBackend(ModelBackend):
-      logger = logging.getLogger('your-kibana-logger')
+    class PythonLoggerBackend:
+        logger = logging.getLogger('your-kibana-logger')
+        
+        def request(self, request_info):
+            pass  # if you don't need it
 
+        def login(self, login_info):
+            self.logger.info(msg='your message', extra=login_info)      
+            
         def crud(self, crud_info):
             self.logger.info(msg='your message', extra=crud_info)
 

--- a/easyaudit/backends.py
+++ b/easyaudit/backends.py
@@ -1,0 +1,16 @@
+import logging
+from easyaudit.models import RequestEvent, CRUDEvent, LoginEvent
+
+logger = logging.getLogger(__name__)
+
+
+class ModelBackend:
+
+    def request(self, request_info):
+        return RequestEvent.objects.create(**request_info)
+
+    def crud(self, crud_info):
+        return CRUDEvent.objects.create(**crud_info)
+
+    def login(self, login_info):
+        return LoginEvent.objects.create(**login_info)

--- a/easyaudit/settings.py
+++ b/easyaudit/settings.py
@@ -31,6 +31,9 @@ WATCH_MODEL_EVENTS = getattr(settings, 'DJANGO_EASY_AUDIT_WATCH_MODEL_EVENTS', T
 WATCH_REQUEST_EVENTS = getattr(settings, 'DJANGO_EASY_AUDIT_WATCH_REQUEST_EVENTS', True)
 REMOTE_ADDR_HEADER = getattr(settings, 'DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER', 'REMOTE_ADDR')
 
+# logging backend settings
+LOGGING_BACKEND = getattr(settings, 'DJANGO_EASY_AUDIT_LOGGING_BACKEND', 'easyaudit.backends.ModelBackend')
+
 
 # Models which Django Easy Audit will not log.
 # By default, all but some models will be audited.

--- a/easyaudit/signals/auth_signals.py
+++ b/easyaudit/signals/auth_signals.py
@@ -6,13 +6,13 @@ from easyaudit.middleware.easyaudit import get_current_request
 from easyaudit.models import LoginEvent
 from easyaudit.settings import REMOTE_ADDR_HEADER, WATCH_AUTH_EVENTS, LOGGING_BACKEND
 
-logger = import_string(LOGGING_BACKEND)()
+audit_logger = import_string(LOGGING_BACKEND)()
 
 
 def user_logged_in(sender, request, user, **kwargs):
     try:
         with transaction.atomic():
-            logger.login({
+            audit_logger.login({
                 'username': getattr(user, user.USERNAME_FIELD),
                 'user': user,
                 'remote_ip': request.META[REMOTE_ADDR_HEADER]
@@ -39,7 +39,7 @@ def user_login_failed(sender, credentials, **kwargs):
         with transaction.atomic():
             request = get_current_request()  # request argument not available in django < 1.11
             user_model = get_user_model()
-            logger.login({
+            audit_logger.login({
                 'login_type': LoginEvent.FAILED,
                 'username': credentials[user_model.USERNAME_FIELD],
                 'remote_ip': request.META[REMOTE_ADDR_HEADER]

--- a/easyaudit/signals/auth_signals.py
+++ b/easyaudit/signals/auth_signals.py
@@ -1,17 +1,22 @@
 from django.contrib.auth import signals, get_user_model
 from django.db import transaction
+from django.utils.module_loading import import_string
 
 from easyaudit.middleware.easyaudit import get_current_request
 from easyaudit.models import LoginEvent
-from easyaudit.settings import REMOTE_ADDR_HEADER, WATCH_AUTH_EVENTS
+from easyaudit.settings import REMOTE_ADDR_HEADER, WATCH_AUTH_EVENTS, LOGGING_BACKEND
+
+logger = import_string(LOGGING_BACKEND)()
+
 
 def user_logged_in(sender, request, user, **kwargs):
     try:
         with transaction.atomic():
-            login_event = LoginEvent.objects.create(login_type=LoginEvent.LOGIN,
-                                     username=getattr(user, user.USERNAME_FIELD),
-                                     user=user,
-                                     remote_ip=request.META[REMOTE_ADDR_HEADER])
+            logger.login({
+                'username': getattr(user, user.USERNAME_FIELD),
+                'user': user,
+                'remote_ip': request.META[REMOTE_ADDR_HEADER]
+            })
     except:
         pass
 
@@ -19,10 +24,12 @@ def user_logged_in(sender, request, user, **kwargs):
 def user_logged_out(sender, request, user, **kwargs):
     try:
         with transaction.atomic():
-            login_event = LoginEvent.objects.create(login_type=LoginEvent.LOGOUT,
-                                                    username=getattr(user, user.USERNAME_FIELD),
-                                                    user=user,
-                                                    remote_ip=request.META[REMOTE_ADDR_HEADER])
+            logger.login({
+                'login_type': LoginEvent.LOGOUT,
+                'username': getattr(user, user.USERNAME_FIELD),
+                'user': user,
+                'remote_ip': request.META[REMOTE_ADDR_HEADER]
+            })
     except:
         pass
 
@@ -30,11 +37,13 @@ def user_logged_out(sender, request, user, **kwargs):
 def user_login_failed(sender, credentials, **kwargs):
     try:
         with transaction.atomic():
-            request = get_current_request() # request argument not available in django < 1.11
+            request = get_current_request()  # request argument not available in django < 1.11
             user_model = get_user_model()
-            login_event = LoginEvent.objects.create(login_type=LoginEvent.FAILED,
-                                                    username=credentials[user_model.USERNAME_FIELD],
-                                                    remote_ip=request.META[REMOTE_ADDR_HEADER])
+            logger.login({
+                'login_type': LoginEvent.FAILED,
+                'username': credentials[user_model.USERNAME_FIELD],
+                'remote_ip': request.META[REMOTE_ADDR_HEADER]
+            })
     except:
         pass
 

--- a/easyaudit/signals/auth_signals.py
+++ b/easyaudit/signals/auth_signals.py
@@ -24,7 +24,7 @@ def user_logged_in(sender, request, user, **kwargs):
 def user_logged_out(sender, request, user, **kwargs):
     try:
         with transaction.atomic():
-            logger.login({
+            audit_logger.login({
                 'login_type': LoginEvent.LOGOUT,
                 'username': getattr(user, user.USERNAME_FIELD),
                 'user': user,

--- a/easyaudit/signals/model_signals.py
+++ b/easyaudit/signals/model_signals.py
@@ -9,16 +9,20 @@ from django.db import transaction
 from django.db.models import signals
 from django.utils import timezone
 from django.utils.encoding import force_text
+from django.utils.module_loading import import_string
+
 
 from easyaudit.middleware.easyaudit import get_current_request,\
                                            get_current_user
 from easyaudit.models import CRUDEvent
 from easyaudit.settings import REGISTERED_CLASSES, UNREGISTERED_CLASSES,\
-                               WATCH_MODEL_EVENTS, CRUD_DIFFERENCE_CALLBACKS
+                               WATCH_MODEL_EVENTS, CRUD_DIFFERENCE_CALLBACKS,\
+                               LOGGING_BACKEND
 from easyaudit.utils import model_delta
 
 
 logger = logging.getLogger(__name__)
+audit_logger = import_string(LOGGING_BACKEND)()
 
 
 def should_audit(instance):
@@ -85,17 +89,17 @@ def pre_save(sender, instance, raw, using, update_fields, **kwargs):
 
             # create crud event only if all callbacks returned True
             if create_crud_event and not created:
-                crud_event = CRUDEvent.objects.create(
-                    event_type=event_type,
-                    object_repr=str(instance),
-                    object_json_repr=object_json_repr,
-                    changed_fields=changed_fields,
-                    content_type=ContentType.objects.get_for_model(instance),
-                    object_id=instance.pk,
-                    user=user,
-                    datetime=timezone.now(),
-                    user_pk_as_string=str(user.pk) if user else user
-                )
+                audit_logger.crud({
+                    'event_type': event_type,
+                    'object_repr': str(instance),
+                    'object_json_repr': object_json_repr,
+                    'changed_fields': changed_fields,
+                    'content_type': ContentType.objects.get_for_model(instance),
+                    'object_id': instance.pk,
+                    'user': user,
+                    'datetime': timezone.now(),
+                    'user_pk_as_string': str(user.pk) if user else user
+                })
     except Exception:
         logger.exception('easy audit had a pre-save exception.')
 
@@ -136,16 +140,16 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
 
             # create crud event only if all callbacks returned True
             if create_crud_event and created:
-                crud_event = CRUDEvent.objects.create(
-                    event_type=event_type,
-                    object_repr=str(instance),
-                    object_json_repr=object_json_repr,
-                    content_type=ContentType.objects.get_for_model(instance),
-                    object_id=instance.pk,
-                    user=user,
-                    datetime=timezone.now(),
-                    user_pk_as_string=str(user.pk) if user else user
-                )
+                audit_logger.crud({
+                    'event_type': event_type,
+                    'object_repr': str(instance),
+                    'object_json_repr': object_json_repr,
+                    'content_type': ContentType.objects.get_for_model(instance),
+                    'object_id': instance.pk,
+                    'user': user,
+                    'datetime': timezone.now(),
+                    'user_pk_as_string': str(user.pk) if user else user
+                })
     except Exception:
         logger.exception('easy audit had a post-save exception.')
 
@@ -206,17 +210,16 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
 
             if isinstance(user, AnonymousUser):
                 user = None
-
-            crud_event = CRUDEvent.objects.create(
-                event_type=event_type,
-                object_repr=str(instance),
-                object_json_repr=object_json_repr,
-                content_type=ContentType.objects.get_for_model(instance),
-                object_id=instance.pk,
-                user=user,
-                datetime=timezone.now(),
-                user_pk_as_string=str(user.pk) if user else user
-            )
+            audit_logger.crud({
+                'event_type': event_type,
+                'object_repr': str(instance),
+                'object_json_repr': object_json_repr,
+                'content_type': ContentType.objects.get_for_model(instance),
+                'object_id': instance.pk,
+                'user': user,
+                'datetime': timezone.now(),
+                'user_pk_as_string': str(user.pk) if user else user
+            })
     except Exception:
         logger.exception('easy audit had an m2m-changed exception.')
 
@@ -242,16 +245,16 @@ def post_delete(sender, instance, using, **kwargs):
                 user = None
 
             # crud event
-            crud_event = CRUDEvent.objects.create(
-                event_type=CRUDEvent.DELETE,
-                object_repr=str(instance),
-                object_json_repr=object_json_repr,
-                content_type=ContentType.objects.get_for_model(instance),
-                object_id=instance.pk,
-                user=user,
-                datetime=timezone.now(),
-                user_pk_as_string=str(user.pk) if user else user
-            )
+            audit_logger.crud({
+                'event_type': CRUDEvent.DELETE,
+                'object_repr': str(instance),
+                'object_json_repr': object_json_repr,
+                'content_type': ContentType.objects.get_for_model(instance),
+                'object_id': instance.pk,
+                'user': user,
+                'datetime': timezone.now(),
+                'user_pk_as_string': str(user.pk) if user else user
+            })
     except Exception:
         logger.exception('easy audit had a post-delete exception.')
 

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -3,12 +3,15 @@ from django.contrib.sessions.models import Session
 from django.core.signals import request_started
 from django.http.cookie import SimpleCookie
 from django.utils import six, timezone
+from django.utils.module_loading import import_string
 from django.conf import settings
 
 from easyaudit.models import RequestEvent
-from easyaudit.settings import REMOTE_ADDR_HEADER, UNREGISTERED_URLS, WATCH_REQUEST_EVENTS
+from easyaudit.settings import REMOTE_ADDR_HEADER, UNREGISTERED_URLS,\
+                               WATCH_REQUEST_EVENTS, LOGGING_BACKEND
 
 import re
+audit_logger = import_string(LOGGING_BACKEND)()
 
 
 def should_log_url(url):
@@ -46,14 +49,14 @@ def request_started_handler(sender, environ, **kwargs):
                 except:
                     user = None
 
-    request_event = RequestEvent.objects.create(
-        url=environ['PATH_INFO'],
-        method=environ['REQUEST_METHOD'],
-        query_string=environ['QUERY_STRING'],
-        user=user,
-        remote_ip=environ[REMOTE_ADDR_HEADER],
-        datetime=timezone.now()
-    )
+    audit_logger.request({
+        'url': environ['PATH_INFO'],
+        'method': environ['REQUEST_METHOD'],
+        'query_string': environ['QUERY_STRING'],
+        'user': user,
+        'remote_ip': environ[REMOTE_ADDR_HEADER],
+        'datetime': timezone.now()
+    })
 
 
 if WATCH_REQUEST_EVENTS:


### PR DESCRIPTION
This PR adds a setting to the library, making it more pluggable to end users.

We have encountered that the database table became too large for our operations, and decided to log our audit events to ElasticSearch instead. With the changes in this pr, it's possible to change the logging backend to whatever the end user prefers, instead of being forced to create a database table for audit logs.

A simple example for kibana is given in the readme.