### PR TITLE
Compatibility with Django 2.x 

### DIFF
--- a/easyaudit/migrations/0009_auto_20180314_2225.py
+++ b/easyaudit/migrations/0009_auto_20180314_2225.py
@@ -20,6 +20,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='requestevent',
             name='url',
-            field=models.TextField(db_index=True),
+            field=models.CharField(db_index=True),
         ),
     ]

--- a/easyaudit/migrations/0009_auto_20180314_2225.py
+++ b/easyaudit/migrations/0009_auto_20180314_2225.py
@@ -20,6 +20,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='requestevent',
             name='url',
-            field=models.CharField(db_index=True),
+            field=models.CharField(db_index=True, max_length=255),
         ),
     ]

--- a/easyaudit/models.py
+++ b/easyaudit/models.py
@@ -70,7 +70,7 @@ class LoginEvent(models.Model):
 
 
 class RequestEvent(models.Model):
-    url = models.TextField(null=False, db_index=True)
+    url = models.CharField(null=False, db_index=True)
     method = models.CharField(max_length=20, null=False, db_index=True)
     query_string = models.TextField(null=True)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True,

--- a/easyaudit/models.py
+++ b/easyaudit/models.py
@@ -70,7 +70,7 @@ class LoginEvent(models.Model):
 
 
 class RequestEvent(models.Model):
-    url = models.CharField(null=False, db_index=True)
+    url = models.CharField(null=False, db_index=True, max_length=255)
     method = models.CharField(max_length=20, null=False, db_index=True)
     query_string = models.TextField(null=True)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True,

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -54,6 +54,7 @@ def request_started_handler(sender, **kwargs):
                 except:
                     user = None
 
+    print('about to save request')
     RequestEvent.objects.create(
         url=path,
         method=method,
@@ -61,7 +62,7 @@ def request_started_handler(sender, **kwargs):
         user=user,
         remote_ip=remote_ip,
         datetime=timezone.now()
-    )
+    ).save()
 
 
 if WATCH_REQUEST_EVENTS:

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -55,7 +55,6 @@ def request_started_handler(sender, **kwargs):
                 except:
                     user = None
 
-    print('about to save request')
     RequestEvent.objects.create(
         url=path,
         method=method,

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -20,40 +20,46 @@ def should_log_url(url):
     return True
 
 
-def request_started_handler(sender, environ, **kwargs):
-    if not should_log_url(environ['PATH_INFO']):
-        return
+def request_started_handler(sender, **kwargs):
+    print(kwargs.get('scope'))
+    print(kwargs.get('scope').get('headers'), type(kwargs.get('scope').get('headers')))
+    # request_scope = kwargs.get('scope')
+    # if request_scope is None:
+    #     return
+    # headers = request_scope.get('headers')
+    # # if not should_log_url(environ['PATH_INFO']):
+    # #     return
 
-    # get the user from cookies
-    user = None
-    if environ.get('HTTP_COOKIE'):
-        cookie = SimpleCookie() # python3 compatibility
-        cookie.load(environ['HTTP_COOKIE'])
+    # # get the user from cookies
+    # user = None
+    # if environ.get('HTTP_COOKIE'):
+    #     cookie = SimpleCookie() # python3 compatibility
+    #     cookie.load(environ['HTTP_COOKIE'])
 
-        session_cookie_name = settings.SESSION_COOKIE_NAME
-        if session_cookie_name in cookie:
-            session_id = cookie[session_cookie_name].value
+    #     session_cookie_name = settings.SESSION_COOKIE_NAME
+    #     if session_cookie_name in cookie:
+    #         session_id = cookie[session_cookie_name].value
 
-            try:
-                session = Session.objects.get(session_key=session_id)
-            except Session.DoesNotExist:
-                session = None
+    #         try:
+    #             session = Session.objects.get(session_key=session_id)
+    #         except Session.DoesNotExist:
+    #             session = None
 
-            if session:
-                user_id = session.get_decoded().get('_auth_user_id')
-                try:
-                    user = get_user_model().objects.get(id=user_id)
-                except:
-                    user = None
+    #         if session:
+    #             user_id = session.get_decoded().get('_auth_user_id')
+    #             try:
+    #                 user = get_user_model().objects.get(id=user_id)
+    #             except:
+    #                 user = None
 
-    request_event = RequestEvent.objects.create(
-        url=environ['PATH_INFO'],
-        method=environ['REQUEST_METHOD'],
-        query_string=environ['QUERY_STRING'],
-        user=user,
-        remote_ip=environ[REMOTE_ADDR_HEADER],
-        datetime=timezone.now()
-    )
+    # request_event = RequestEvent.objects.create(
+    #     url=environ['PATH_INFO'],
+    #     method=environ['REQUEST_METHOD'],
+    #     query_string=environ['QUERY_STRING'],
+    #     user=user,
+    #     remote_ip=environ[REMOTE_ADDR_HEADER],
+    #     datetime=timezone.now()
+    # )
 
 
 if WATCH_REQUEST_EVENTS:

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -27,7 +27,8 @@ def request_started_handler(sender, **kwargs):
     method = scope.get('method')
     path = scope.get('path')
     query_string = scope.get('query_string')
-    remote_ip = ':'.join(scope.get('server'))
+    server = scope.get('server')
+    remote_ip = f'{server[0]}:{server[1]}'
     
     if not should_log_url(path):
         return

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -21,45 +21,47 @@ def should_log_url(url):
 
 
 def request_started_handler(sender, **kwargs):
-    print(kwargs.get('scope'))
-    print(kwargs.get('scope').get('headers'), type(kwargs.get('scope').get('headers')))
-    # request_scope = kwargs.get('scope')
-    # if request_scope is None:
-    #     return
-    # headers = request_scope.get('headers')
-    # # if not should_log_url(environ['PATH_INFO']):
-    # #     return
+    scope = kwargs.get('scope')
+    headers = dict(scope.get('headers'))
+    cookie = headers.get(b'cookie')
+    method = scope.get('method')
+    path = scope.get('path')
+    query_string = scope.get('query_string')
+    remote_ip = ':'.join(scope.get('server'))
+    
+    if not should_log_url(path):
+        return
 
-    # # get the user from cookies
-    # user = None
-    # if environ.get('HTTP_COOKIE'):
-    #     cookie = SimpleCookie() # python3 compatibility
-    #     cookie.load(environ['HTTP_COOKIE'])
+    # get the user from cookies
+    user = None
+    if cookie:
+        cookie = SimpleCookie() # python3 compatibility
+        cookie.load(cookie)
 
-    #     session_cookie_name = settings.SESSION_COOKIE_NAME
-    #     if session_cookie_name in cookie:
-    #         session_id = cookie[session_cookie_name].value
+        session_cookie_name = settings.SESSION_COOKIE_NAME
+        if session_cookie_name in cookie:
+            session_id = cookie[session_cookie_name].value
 
-    #         try:
-    #             session = Session.objects.get(session_key=session_id)
-    #         except Session.DoesNotExist:
-    #             session = None
+            try:
+                session = Session.objects.get(session_key=session_id)
+            except Session.DoesNotExist:
+                session = None
 
-    #         if session:
-    #             user_id = session.get_decoded().get('_auth_user_id')
-    #             try:
-    #                 user = get_user_model().objects.get(id=user_id)
-    #             except:
-    #                 user = None
+            if session:
+                user_id = session.get_decoded().get('_auth_user_id')
+                try:
+                    user = get_user_model().objects.get(id=user_id)
+                except:
+                    user = None
 
-    # request_event = RequestEvent.objects.create(
-    #     url=environ['PATH_INFO'],
-    #     method=environ['REQUEST_METHOD'],
-    #     query_string=environ['QUERY_STRING'],
-    #     user=user,
-    #     remote_ip=environ[REMOTE_ADDR_HEADER],
-    #     datetime=timezone.now()
-    # )
+    RequestEvent.objects.create(
+        url=path,
+        method=method,
+        query_string=query_string,
+        user=user,
+        remote_ip=remote_ip,
+        datetime=timezone.now()
+    )
 
 
 if WATCH_REQUEST_EVENTS:


### PR DESCRIPTION
# Goal
The goal of this PR is to allow compatibility between easy_audit and Django v 2.x.

# Implementation Details
Django 2 signal receivers do not accept an `environ` parameter anymore. Instead, this information is taken from the request scope.

# Discussion
Also, I've updated the URL column to use a Charfield, so that the library accommodates MySQL users.