### PR TITLE
Fix for Issue #97

### DIFF
--- a/easyaudit/signals/model_signals.py
+++ b/easyaudit/signals/model_signals.py
@@ -67,7 +67,7 @@ def pre_save(sender, instance, raw, using, update_fields, **kwargs):
             if not created:
                 old_model = sender.objects.get(pk=instance.pk)
                 delta = model_delta(old_model, instance)
-                changed_fields = json.dumps(delta)
+                changed_fields = json.dumps(delta) if delta else None
                 event_type = CRUDEvent.UPDATE
 
             # user


### PR DESCRIPTION
This PR changes the behaviour of 'Update' events so that no value is stored in a CRUDEvent objects `changed_fields` attribute instead of a literal 'null' string if nothing actually changed on the record.

This is a short-term / quick fix for #97.