### PR TITLE
Add a pluggable logging backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,35 @@ Below are some of the settings you may want to use. These should be defined in y
     - ['login_type', 'user', 'datetime', ] for LoginEventAdmin
     - ['method', 'user', 'datetime', ] for RequestEventAdmin
 
+* `DJANGO_EASY_AUDIT_LOGGING_BACKEND`
+
+  A pluggable backend option for logging. Defaults to `easyaudit.backends.ModelBackend`.
+  This class expects to have 3 methods: 
+  * `login(self, login_info_dict):`  
+  * `crud(self, crud_info_dict):`  
+  * `request(self, request_info_dict):`
+
+  each of these methods accept a dictionary containing the info regarding the event.  
+  example overriding:
+  ```python
+    import logging
+    
+    class PythonLoggerBackend:
+        logging.basicConfig()
+        logger = logging.getLogger('your-kibana-logger')
+        logger.setLevel(logging.DEBUG)
+        
+        def request(self, request_info):
+            return request_info # if you don't need it
+        
+        def login(self, login_info):
+            self.logger.info(msg='your message', extra=login_info)      
+            return login_info      
+              
+        def crud(self, crud_info):
+            self.logger.info(msg='your message', extra=crud_info)
+            return crud_info
+    ```
 ## What does it do
 
 Django Easy Audit uses [Django signals](https://docs.djangoproject.com/en/dev/topics/signals/)

--- a/easyaudit/backends.py
+++ b/easyaudit/backends.py
@@ -1,0 +1,16 @@
+import logging
+from easyaudit.models import RequestEvent, CRUDEvent, LoginEvent
+
+logger = logging.getLogger(__name__)
+
+
+class ModelBackend:
+
+    def request(self, request_info):
+        return RequestEvent.objects.create(**request_info)
+
+    def crud(self, crud_info):
+        return CRUDEvent.objects.create(**crud_info)
+
+    def login(self, login_info):
+        return LoginEvent.objects.create(**login_info)

--- a/easyaudit/settings.py
+++ b/easyaudit/settings.py
@@ -31,6 +31,8 @@ REMOTE_ADDR_HEADER = getattr(settings, 'DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER', '
 
 USER_DB_CONSTRAINT = bool(getattr(settings, 'DJANGO_EASY_AUDIT_USER_DB_CONSTRAINT', True))
 
+# logging backend settings
+LOGGING_BACKEND = getattr(settings, 'DJANGO_EASY_AUDIT_LOGGING_BACKEND', 'easyaudit.backends.ModelBackend')
 
 # Models which Django Easy Audit will not log.
 # By default, all but some models will be audited.

--- a/easyaudit/signals/auth_signals.py
+++ b/easyaudit/signals/auth_signals.py
@@ -16,7 +16,7 @@ def user_logged_in(sender, request, user, **kwargs):
                 'login_type': LoginEvent.LOGIN,
                 'username': getattr(user, user.USERNAME_FIELD),
                 'user_id': getattr(user, 'id', None),
-                'remote_ip': request.META[REMOTE_ADDR_HEADER])
+                'remote_ip': request.META[REMOTE_ADDR_HEADER]
             })
     except:
         pass
@@ -29,7 +29,7 @@ def user_logged_out(sender, request, user, **kwargs):
                 'login_type': LoginEvent.LOGOUT,
                 'username': getattr(user, user.USERNAME_FIELD),
                 'user_id': getattr(user, 'id', None),
-                'remote_ip': request.META[REMOTE_ADDR_HEADER])
+                'remote_ip': request.META[REMOTE_ADDR_HEADER]
             })
     except:
         pass
@@ -43,7 +43,7 @@ def user_login_failed(sender, credentials, **kwargs):
             login_event = audit_logger.login({
                 'login_type': LoginEvent.FAILED,
                 'username': getattr(user, user.USERNAME_FIELD),
-                'remote_ip': request.META[REMOTE_ADDR_HEADER])
+                'remote_ip': request.META[REMOTE_ADDR_HEADER]
             })
     except:
         pass

--- a/easyaudit/signals/auth_signals.py
+++ b/easyaudit/signals/auth_signals.py
@@ -42,7 +42,7 @@ def user_login_failed(sender, credentials, **kwargs):
             user_model = get_user_model()
             login_event = audit_logger.login({
                 'login_type': LoginEvent.FAILED,
-                'username': getattr(user, user.USERNAME_FIELD),
+                'username': credentials[user_model.USERNAME_FIELD],
                 'remote_ip': request.META[REMOTE_ADDR_HEADER]
             })
     except:

--- a/easyaudit/signals/auth_signals.py
+++ b/easyaudit/signals/auth_signals.py
@@ -1,17 +1,23 @@
 from django.contrib.auth import signals, get_user_model
 from django.db import transaction
+from django.utils.module_loading import import_string
 
 from easyaudit.middleware.easyaudit import get_current_request
 from easyaudit.models import LoginEvent
-from easyaudit.settings import REMOTE_ADDR_HEADER, WATCH_AUTH_EVENTS
+from easyaudit.settings import REMOTE_ADDR_HEADER, WATCH_AUTH_EVENTS, LOGGING_BACKEND
+
+audit_logger = import_string(LOGGING_BACKEND)()
+
 
 def user_logged_in(sender, request, user, **kwargs):
     try:
         with transaction.atomic():
-            login_event = LoginEvent.objects.create(login_type=LoginEvent.LOGIN,
-                                     username=getattr(user, user.USERNAME_FIELD),
-                                     user_id=getattr(user, 'id', None),
-                                     remote_ip=request.META[REMOTE_ADDR_HEADER])
+            login_event = audit_logger.login({
+                'login_type': LoginEvent.LOGIN,
+                'username': getattr(user, user.USERNAME_FIELD),
+                'user_id': getattr(user, 'id', None),
+                'remote_ip': request.META[REMOTE_ADDR_HEADER])
+            })
     except:
         pass
 
@@ -19,10 +25,12 @@ def user_logged_in(sender, request, user, **kwargs):
 def user_logged_out(sender, request, user, **kwargs):
     try:
         with transaction.atomic():
-            login_event = LoginEvent.objects.create(login_type=LoginEvent.LOGOUT,
-                                                    username=getattr(user, user.USERNAME_FIELD, None),
-                                                    user_id=getattr(user, 'id', None),
-                                                    remote_ip=request.META[REMOTE_ADDR_HEADER])
+            login_event = audit_logger.login({
+                'login_type': LoginEvent.LOGOUT,
+                'username': getattr(user, user.USERNAME_FIELD),
+                'user_id': getattr(user, 'id', None),
+                'remote_ip': request.META[REMOTE_ADDR_HEADER])
+            })
     except:
         pass
 
@@ -32,9 +40,11 @@ def user_login_failed(sender, credentials, **kwargs):
         with transaction.atomic():
             request = get_current_request() # request argument not available in django < 1.11
             user_model = get_user_model()
-            login_event = LoginEvent.objects.create(login_type=LoginEvent.FAILED,
-                                                    username=credentials[user_model.USERNAME_FIELD],
-                                                    remote_ip=request.META[REMOTE_ADDR_HEADER])
+            login_event = audit_logger.login({
+                'login_type': LoginEvent.FAILED,
+                'username': getattr(user, user.USERNAME_FIELD),
+                'remote_ip': request.META[REMOTE_ADDR_HEADER])
+            })
     except:
         pass
 

--- a/easyaudit/signals/model_signals.py
+++ b/easyaudit/signals/model_signals.py
@@ -9,15 +9,17 @@ from django.db import transaction
 from django.db.models import signals
 from django.utils import timezone
 from django.utils.encoding import force_text
+from django.utils.module_loading import import_string
 
 from easyaudit.middleware.easyaudit import get_current_request, \
     get_current_user
 from easyaudit.models import CRUDEvent
 from easyaudit.settings import REGISTERED_CLASSES, UNREGISTERED_CLASSES, \
-    WATCH_MODEL_EVENTS, CRUD_DIFFERENCE_CALLBACKS
+    WATCH_MODEL_EVENTS, CRUD_DIFFERENCE_CALLBACKS, LOGGING_BACKEND
 from easyaudit.utils import model_delta
 
 logger = logging.getLogger(__name__)
+audit_logger = import_string(LOGGING_BACKEND)()
 
 
 def should_audit(instance):
@@ -92,17 +94,17 @@ def pre_save(sender, instance, raw, using, update_fields, **kwargs):
                 sid = transaction.savepoint()
                 try:
                     with transaction.atomic():
-                        crud_event = CRUDEvent.objects.create(
-                            event_type=event_type,
-                            object_repr=str(instance),
-                            object_json_repr=object_json_repr,
-                            changed_fields=changed_fields,
-                            content_type_id=c_t.id,
-                            object_id=instance.pk,
-                            user_id=getattr(user, 'id', None),
-                            datetime=timezone.now(),
-                            user_pk_as_string=str(user.pk) if user else user
-                        )
+                        crud_event = audit_logger.crud({
+                            'event_type': event_type,
+                            'object_repr': str(instance),
+                            'object_json_repr': object_json_repr,
+                            'changed_fields': changed_fields,
+                            'content_type_id': c_t.id,
+                            'object_id': instance.pk,
+                            'user_id': getattr(user, 'id', None),
+                            'datetime': timezone.now(),
+                            'user_pk_as_string': str(user.pk) if user else user
+                        })
                 except Exception as e:
                     logger.exception(
                         "easy audit had a pre-save exception on CRUDEvent creation. instance: {}, instance pk: {}".format(
@@ -152,16 +154,16 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
                 sid = transaction.savepoint()
                 try:
                     with transaction.atomic():
-                        crud_event = CRUDEvent.objects.create(
-                            event_type=event_type,
-                            object_repr=str(instance),
-                            object_json_repr=object_json_repr,
-                            content_type_id=c_t.id,
-                            object_id=instance.pk,
-                            user_id=getattr(user, 'id', None),
-                            datetime=timezone.now(),
-                            user_pk_as_string=str(user.pk) if user else user
-                        )
+                        crud_event = audit_logger.crud({
+                            'event_type': event_type,
+                            'object_repr': str(instance),
+                            'object_json_repr': object_json_repr,
+                            'content_type_id': c_t.id,
+                            'object_id': instance.pk,
+                            'user_id': getattr(user, 'id', None),
+                            'datetime': timezone.now(),
+                            'user_pk_as_string': str(user.pk) if user else user
+                        })
                 except Exception as e:
                     logger.exception(
                         "easy audit had a pre-save exception on CRUDEvent creation. instance: {}, instance pk: {}".format(
@@ -232,16 +234,16 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
 
             try:
                 with transaction.atomic():
-                    crud_event = CRUDEvent.objects.create(
-                        event_type=event_type,
-                        object_repr=str(instance),
-                        object_json_repr=object_json_repr,
-                        content_type_id=c_t.id,
-                        object_id=instance.pk,
-                        user_id=getattr(user, 'id', None),
-                        datetime=timezone.now(),
-                        user_pk_as_string=str(user.pk) if user else user
-                    )
+                    crud_event = audit_logger.crud({
+                        'event_type': event_type,
+                        'object_repr': str(instance),
+                        'object_json_repr': object_json_repr,
+                        'content_type_id': c_t.id,
+                        'object_id': instance.pk,
+                        'user_id': getattr(user, 'id', None),
+                        'datetime': timezone.now(),
+                        'user_pk_as_string': str(user.pk) if user else user
+                    })
             except Exception as e:
                 logger.exception(
                     "easy audit had a pre-save exception on CRUDEvent creation. instance: {}, instance pk: {}".format(
@@ -274,17 +276,16 @@ def post_delete(sender, instance, using, **kwargs):
             sid = transaction.savepoint()
             try:
                 with transaction.atomic():
-                    # crud event
-                    crud_event = CRUDEvent.objects.create(
-                        event_type=CRUDEvent.DELETE,
-                        object_repr=str(instance),
-                        object_json_repr=object_json_repr,
-                        content_type_id=c_t.id,
-                        object_id=instance.pk,
-                        user_id=getattr(user, 'id', None),
-                        datetime=timezone.now(),
-                        user_pk_as_string=str(user.pk) if user else user
-                    )
+                    crud_event = audit_logger.crud({
+                        'event_type': CRUDEvent.DELETE,
+                        'object_repr': str(instance),
+                        'object_json_repr': object_json_repr,
+                        'content_type_id': c_t.id,
+                        'object_id': instance.pk,
+                        'user_id': getattr(user, 'id', None),
+                        'datetime': timezone.now(),
+                        'user_pk_as_string': str(user.pk) if user else user
+                    })
 
             except Exception as e:
                 logger.exception(


### PR DESCRIPTION
This PR adds a setting to the library, making it more pluggable to end users.

We have encountered that the database table became too large for our operations, and decided to log our audit events to ElasticSearch instead. With the changes in this pr, it's possible to change the logging backend to whatever the end user prefers, instead of being forced to create a database table for audit logs.

A simple example for kibana is given in the readme.