### PR TITLE
Read only events admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Below are some of the settings you may want to use. These should be defined in y
   
   To clarify, this is only _truly_ necessary for the model signals.
 
+* `DJANGO_EASY_AUDIT_READONLY_EVENTS`
+
+  Default is `False`. The events visible through the admin interface are editable by default by a
+  superuser. Set this to `True` if you wish to make the recorded events read-only through the admin
+  UI.
+
 ## What does it do
 
 Django Easy Audit uses [Django signals](https://docs.djangoproject.com/en/dev/topics/signals/)

--- a/easyaudit/admin.py
+++ b/easyaudit/admin.py
@@ -15,20 +15,15 @@ from .settings import (CRUD_EVENT_LIST_FILTER, LOGIN_EVENT_LIST_FILTER, REQUEST_
                        CRUD_EVENT_SEARCH_FIELDS, LOGIN_EVENT_SEARCH_FIELDS, REQUEST_EVENT_SEARCH_FIELDS,
                        READONLY_EVENTS)
 
-
-readonly_fields = ['event_type', 'object_id', 'get_content_type',
-                   'object_repr', 'object_json_repr_prettified', 'get_user',
-                   'user_pk_as_string', 'datetime', 'changed_fields_prettified']
-if READONLY_EVENTS:
-    readonly_fields = readonly_fields + ['user', 'content_type']
-
 # CRUD events
 class CRUDEventAdmin(EasyAuditModelAdmin):
     list_display = ['get_event_type_display', 'get_content_type', 'object_id', 'object_repr_link', 'user_link', 'datetime']
     date_hierarchy = 'datetime'
     list_filter = CRUD_EVENT_LIST_FILTER
     search_fields = CRUD_EVENT_SEARCH_FIELDS
-    readonly_fields = readonly_fields
+    readonly_fields = ['event_type', 'object_id', 'get_content_type',
+                       'object_repr', 'object_json_repr_prettified', 'get_user',
+                       'user_pk_as_string', 'datetime', 'changed_fields_prettified']
     exclude = ['object_json_repr', 'changed_fields']
 
     def get_content_type(self, obj):

--- a/easyaudit/admin.py
+++ b/easyaudit/admin.py
@@ -28,9 +28,7 @@ class CRUDEventAdmin(EasyAuditModelAdmin):
     date_hierarchy = 'datetime'
     list_filter = CRUD_EVENT_LIST_FILTER
     search_fields = CRUD_EVENT_SEARCH_FIELDS
-    readonly_fields = ['event_type', 'object_id', 'get_content_type',
-                       'object_repr', 'object_json_repr_prettified', 'get_user',
-                       'user_pk_as_string', 'datetime', 'changed_fields_prettified']
+    readonly_fields = readonly_fields
     exclude = ['object_json_repr', 'changed_fields']
 
     def get_content_type(self, obj):

--- a/easyaudit/admin.py
+++ b/easyaudit/admin.py
@@ -12,8 +12,15 @@ from . import settings
 from .models import CRUDEvent, LoginEvent, RequestEvent
 from .admin_helpers import prettify_json, EasyAuditModelAdmin
 from .settings import (CRUD_EVENT_LIST_FILTER, LOGIN_EVENT_LIST_FILTER, REQUEST_EVENT_LIST_FILTER,
-                       CRUD_EVENT_SEARCH_FIELDS, LOGIN_EVENT_SEARCH_FIELDS, REQUEST_EVENT_SEARCH_FIELDS)
+                       CRUD_EVENT_SEARCH_FIELDS, LOGIN_EVENT_SEARCH_FIELDS, REQUEST_EVENT_SEARCH_FIELDS,
+                       READONLY_EVENTS)
 
+
+readonly_fields = ['event_type', 'object_id', 'get_content_type',
+                   'object_repr', 'object_json_repr_prettified', 'get_user',
+                   'user_pk_as_string', 'datetime', 'changed_fields_prettified']
+if READONLY_EVENTS:
+    readonly_fields = readonly_fields + ['user', 'content_type']
 
 # CRUD events
 class CRUDEventAdmin(EasyAuditModelAdmin):

--- a/easyaudit/admin_helpers.py
+++ b/easyaudit/admin_helpers.py
@@ -54,11 +54,9 @@ class EasyAuditModelAdmin(admin.ModelAdmin):
     def get_urls(self):
         info = self.model._meta.app_label, self.model._meta.model_name
         urls = super(EasyAuditModelAdmin, self).get_urls()
-        my_urls = []
-        if not settings.READONLY_EVENTS:
-            my_urls = [
-                url(r'^purge/$', self.admin_site.admin_view(self.purge), {}, name="%s_%s_purge" % info),
-            ]
+        my_urls = [
+            url(r'^purge/$', self.admin_site.admin_view(self.purge), {}, name="%s_%s_purge" % info),
+        ]
         return my_urls + urls
 
     def purge(self, request):
@@ -73,7 +71,7 @@ class EasyAuditModelAdmin(admin.ModelAdmin):
         """
 
         if settings.READONLY_EVENTS:
-            return HttpResponse('Unauthorized', status=401)
+            raise PermissionDenied
 
         def truncate_table(model):
             if settings.TRUNCATE_TABLE_SQL_STATEMENT:

--- a/easyaudit/admin_helpers.py
+++ b/easyaudit/admin_helpers.py
@@ -31,6 +31,13 @@ def prettify_json(json_string):
 
 class EasyAuditModelAdmin(admin.ModelAdmin):
 
+    def get_readonly_fields(self, request, obj=None):
+        "Mark all fields of model as readonly if configured to do so."
+        if settings.READONLY_EVENTS:
+            return [f.name for f in self.model._meta.get_fields()]
+        else:
+            return self.readonly_fields
+
     def user_link(self, obj):
         user = get_user_model().objects.filter(id=obj.user_id).first()
         #return mark_safe(get_user_link(user))
@@ -50,7 +57,7 @@ class EasyAuditModelAdmin(admin.ModelAdmin):
 
     def has_add_permission(self, request, obj=None):
         return False
-    
+
     def has_delete_permission(self, request, obj=None):
         if settings.READONLY_EVENTS:
             return False

--- a/easyaudit/admin_helpers.py
+++ b/easyaudit/admin_helpers.py
@@ -50,6 +50,11 @@ class EasyAuditModelAdmin(admin.ModelAdmin):
 
     def has_add_permission(self, request, obj=None):
         return False
+    
+    def has_delete_permission(self, request, obj=None):
+        if settings.READONLY_EVENTS:
+            return False
+        return True
 
     def get_urls(self):
         info = self.model._meta.app_label, self.model._meta.model_name

--- a/easyaudit/admin_helpers.py
+++ b/easyaudit/admin_helpers.py
@@ -55,7 +55,7 @@ class EasyAuditModelAdmin(admin.ModelAdmin):
         info = self.model._meta.app_label, self.model._meta.model_name
         urls = super(EasyAuditModelAdmin, self).get_urls()
         my_urls = []
-        if not settings.READONLY_EVENTS
+        if not settings.READONLY_EVENTS:
             my_urls = [
                 url(r'^purge/$', self.admin_site.admin_view(self.purge), {}, name="%s_%s_purge" % info),
             ]

--- a/easyaudit/settings.py
+++ b/easyaudit/settings.py
@@ -110,3 +110,5 @@ REQUEST_EVENT_LIST_FILTER = getattr(settings, 'DJANGO_EASY_AUDIT_REQUEST_EVENT_L
 CRUD_EVENT_SEARCH_FIELDS = getattr(settings, 'DJANGO_EASY_AUDIT_CRUD_EVENT_SEARCH_FIELDS', ['=object_id', 'object_json_repr', ])
 LOGIN_EVENT_SEARCH_FIELDS = getattr(settings, 'DJANGO_EASY_AUDIT_LOGIN_EVENT_SEARCH_FIELDS', ['=remote_ip', 'username', ])
 REQUEST_EVENT_SEARCH_FIELDS = getattr(settings, 'DJANGO_EASY_AUDIT_REQUEST_EVENT_SEARCH_FIELDS', ['=remote_ip', 'user__username', 'url', 'query_string', ])
+
+READONLY_EVENTS = getattr(settings, 'DJANGO_EASY_AUDIT_READONLY_EVENTS', False)

--- a/easyaudit/tests/test_app/tests.py
+++ b/easyaudit/tests/test_app/tests.py
@@ -157,4 +157,3 @@ class TestAuditAdmin(TestCase):
         response = self.client.get(reverse('admin:easyaudit_requestevent_changelist'))
         self.assertEqual(200, response.status_code)
         filters = self._list_filters(response.content)
-        print(filters)


### PR DESCRIPTION
Add the setting `DJANGO_EASY_AUDIT_READONLY_EVENTS` to make CRUD events read-only from the admin UI.

Setting to True will do the following:

- Disable purge
- Set CRUDEvent delete permission to false
- Set all fields of CRUDEvent to read-only

Note: _The details view of the CRUDEvent retains a "save" button, but no change can be made._