### PR TITLE
Increase admin list panel performance by selecting related

### DIFF
--- a/easyaudit/admin.py
+++ b/easyaudit/admin.py
@@ -25,14 +25,15 @@ class CRUDEventAdmin(EasyAuditModelAdmin):
                        'object_repr', 'object_json_repr_prettified', 'get_user',
                        'user_pk_as_string', 'datetime', 'changed_fields_prettified']
     exclude = ['object_json_repr', 'changed_fields']
+    list_select_related = ["content_type", "user"]
 
     def get_content_type(self, obj):
-        return ContentType.objects.get(id=obj.content_type_id)
+        return obj.content_type
 
     get_content_type.short_description = "Content Type"
 
     def get_user(self, obj):
-        return get_user_model().objects.filter(id=obj.user_id).first()
+        return obj.user
 
     get_user.short_description = "User"
 
@@ -76,12 +77,12 @@ class LoginEventAdmin(EasyAuditModelAdmin):
     readonly_fields = ['login_type', 'get_username', 'get_user', 'remote_ip', 'datetime', ]
 
     def get_user(self, obj):
-        return get_user_model().objects.filter(id=obj.user_id).first()
+        return obj.user
 
     get_user.short_description = "User"
 
     def get_username(self, obj):
-        user = get_user_model().objects.filter(id=obj.user_id).first()
+        user = obj.user
         username = user.get_username() if user else None
         return username
 
@@ -101,7 +102,7 @@ class RequestEventAdmin(EasyAuditModelAdmin):
     readonly_fields = ['url', 'method', 'query_string', 'get_user', 'remote_ip', 'datetime', ]
 
     def get_user(self, obj):
-        return get_user_model().objects.filter(id=obj.user_id).first()
+        return obj.user
 
     get_user.short_description = "User"
 

--- a/easyaudit/admin_helpers.py
+++ b/easyaudit/admin_helpers.py
@@ -30,10 +30,14 @@ def prettify_json(json_string):
 
 
 class EasyAuditModelAdmin(admin.ModelAdmin):
-    list_select_related = ["user"]
+    def get_changelist_instance(self, *args, **kwargs):
+        changelist_instance = super().get_changelist_instance(*args, **kwargs)
+        user_ids = [obj.user_id for obj in changelist_instance.result_list]
+        self.users_by_id = {user.id: user for user in get_user_model().objects.filter(id__in=user_ids)}
+        return changelist_instance
 
     def user_link(self, obj):
-        user = obj.user
+        user = self.users_by_id.get(obj.user_id)
         #return mark_safe(get_user_link(user))
         if user is None:
             return '-'

--- a/easyaudit/admin_helpers.py
+++ b/easyaudit/admin_helpers.py
@@ -30,9 +30,10 @@ def prettify_json(json_string):
 
 
 class EasyAuditModelAdmin(admin.ModelAdmin):
+    list_select_related = ["user"]
 
     def user_link(self, obj):
-        user = get_user_model().objects.filter(id=obj.user_id).first()
+        user = obj.user
         #return mark_safe(get_user_link(user))
         if user is None:
             return '-'


### PR DESCRIPTION
The list view in the admin panels is quite slow, especially for the CRUD events. The reason is that it has to do separate queries for the user (and the content type for CRUD events) for each row. This change ensures that all those related objects are fetched in the original query, which gives a pretty massive speed-up.