### PR TITLE
Allow dynamic model registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Below are some of the settings you may want to use. These should be defined in y
 
   A list of Django models which will be ignored by Django Easy Audit.
   Use it to prevent logging one or more of your project's models.
-  List items can be classes or strings with `app_name.model_name` format.
+  List items can be classes, strings with `app_name.model_name` format or functions that will return classes.
 
 * `DJANGO_EASY_AUDIT_UNREGISTERED_URLS_EXTRA`
 

--- a/easyaudit/settings.py
+++ b/easyaudit/settings.py
@@ -1,5 +1,5 @@
-
 from importlib import import_module
+from inspect import isfunction
 
 import django.db.utils
 from django.apps import apps
@@ -22,6 +22,9 @@ def get_model_list(class_list):
     for idx, item in enumerate(class_list):
         if isinstance(item, (str,)):
             model_class = apps.get_model(item)
+            class_list[idx] = model_class
+        elif isfunction(item):
+            model_class = item()
             class_list[idx] = model_class
 
 


### PR DESCRIPTION
The built-in `User` model can't be fetched by a `apps.get_model()` nor given as class as they would go in a recursive import.

```py
# settings.py
from django.contrib.auth import get_user_model() # <= recursive import of settings!
```

This allows to do the following instead:

```py
# settings.py
def lazy_user_model():
    from django.contrib.auth import get_user_model()
    return get_user_model()

DJANGO_EASY_AUDIT_REGISTERED_CLASSES = [
    lazy_user_model
]
```