### PR TITLE
ASGI RequestEvent support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,14 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
-        django-version: [2.2, 2.2.8, 3.0]
+        django-version: [2.2, 2.2.8, 3.0, 3.1]
         exclude:
           - python-version: 3.5
             django-version: 2.2.8
           - python-version: 3.5
             django-version: 3.0
+          - python-version: 3.5
+            django-version: 3.1
           - python-version: 3.8
             django-version: 2.2
 
@@ -28,7 +30,6 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install django==${{ matrix.django-version }}
         python -m pip install -e .
     - name: Run Tests
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ env:
     - DJANGO="django>=2.2,<2.2.8"
     - DJANGO="django>=2.2.8,<3.0"
     - DJANGO="django>=3.0,<3.1"
+    - DJANGO="django>=3.1,<3.2"
 
 install:
-    - pip install ${DJANGO}
     - pip install -e .
 
 before_script:
@@ -28,6 +28,8 @@ matrix:
   exclude:
     - python: "3.5"
       env: DJANGO="django>=3.0,<3.1"
+    - python: "3.5"
+      env: DJANGO="django>=3.1,<3.2"
     - python: "3.8"
       env: DJANGO="django>=2.0,<2.1"
     - python: "3.8"

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -35,17 +35,35 @@ def should_log_url(url):
     return True
 
 
-def request_started_handler(sender, environ, **kwargs):
-    if not should_log_url(environ['PATH_INFO']):
+def request_started_handler(sender, **kwargs):
+    environ = kwargs.get("environ")
+    scope = kwargs.get("scope")
+    if environ:
+        path = environ["PATH_INFO"]
+        cookie_string = environ.get('HTTP_COOKIE')
+        remote_ip = environ[REMOTE_ADDR_HEADER]
+        method = environ['REQUEST_METHOD']
+        query_string = environ["QUERY_STRING"]
+
+    else:
+        method = scope.get('method')
+        path = scope.get("path")
+        headers = dict(scope.get('headers'))
+        cookie_string = headers.get(b'cookie')
+        server = scope.get('server')
+        remote_ip = '{s_ip}:{s_port}'.format(s_ip=server[0], s_port=server[1])
+        query_string = scope.get("query_string")
+
+    if not should_log_url(path):
         return
 
     # try and get the user from the request; commented for now, may have a bug in this flow.
     # user = get_current_user()
     user = None
     # get the user from cookies
-    if not user and environ.get('HTTP_COOKIE'):
-        cookie = SimpleCookie() # python3 compatibility
-        cookie.load(environ['HTTP_COOKIE'])
+    if not user and cookie_string:
+        cookie = SimpleCookie()
+        cookie.load(cookie_string)
 
         session_cookie_name = settings.SESSION_COOKIE_NAME
         if session_cookie_name in cookie:
@@ -63,12 +81,14 @@ def request_started_handler(sender, environ, **kwargs):
                 except:
                     user = None
 
+
+    # may want to wrap this in an atomic transaction later
     request_event = audit_logger.request({
-        'url': environ['PATH_INFO'],
-        'method': environ['REQUEST_METHOD'],
-        'query_string': environ['QUERY_STRING'],
+        'url': path,
+        'method': method,
+        'query_string': query_string,
         'user_id': getattr(user, 'id', None),
-        'remote_ip': environ[REMOTE_ADDR_HEADER],
+        'remote_ip': remote_ip,
         'datetime': timezone.now()
     })
 

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -50,6 +50,8 @@ def request_started_handler(sender, **kwargs):
         path = scope.get("path")
         headers = dict(scope.get('headers'))
         cookie_string = headers.get(b'cookie')
+        if isinstance(cookie_string, bytes):
+            cookie_string = cookie_string.decode("utf-8")
         server = scope.get('server')
         remote_ip = '{s_ip}:{s_port}'.format(s_ip=server[0], s_port=server[1])
         query_string = scope.get("query_string")
@@ -64,7 +66,6 @@ def request_started_handler(sender, **kwargs):
     if not user and cookie_string:
         cookie = SimpleCookie()
         cookie.load(cookie_string)
-
         session_cookie_name = settings.SESSION_COOKIE_NAME
         if session_cookie_name in cookie:
             session_id = cookie[session_cookie_name].value

--- a/easyaudit/tests/test_app/urls.py
+++ b/easyaudit/tests/test_app/urls.py
@@ -4,6 +4,7 @@ from test_app import views
 app_name = 'test_easyaudit'
 
 urlpatterns = [
+    url("index", views.index, name="index"),
     url("create-obj", views.create_obj_view, name="create-obj"),
     url("update-obj", views.update_obj_view, name="update-obj"),
 

--- a/easyaudit/tests/test_app/views.py
+++ b/easyaudit/tests/test_app/views.py
@@ -16,7 +16,12 @@ def update_obj(Model, pk, name):
 
 
 def create_obj_view(request):
-    return HttpResponse(create_obj(TestModel).id)
+    obj = create_obj(TestModel)
+    return HttpResponse(obj.id)
+
+
+def index(request):
+    return HttpResponse()
 
 
 def update_obj_view(request):

--- a/easyaudit/tests/test_project/asgi.py
+++ b/easyaudit/tests/test_project/asgi.py
@@ -1,0 +1,16 @@
+"""
+ASGI config for test_projject project.
+
+It exposes the ASGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/3.0/howto/deployment/asgi/
+"""
+
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_project.settings')
+
+application = get_asgi_application()

--- a/easyaudit/tests/test_project/settings.py
+++ b/easyaudit/tests/test_project/settings.py
@@ -71,6 +71,7 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'test_project.wsgi.application'
+ASGI_APPLICATION = 'test_project.asgi.application'
 
 
 # Database

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ setup(
     include_package_data=True,
     install_requires=[
         "beautifulsoup4",
+        "django>=2.2,<3.2"
     ],
+    python_requires=">=3.5",
     license='GPL3',
     description='Yet another Django audit log app, hopefully the simplest one.',
     long_description=README,

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Framework :: Django',
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
+        "Framework :: Django :: 3.1",
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: OS Independent',


### PR DESCRIPTION
I have also created a test which utilizes ASGI (the view being called is synchronous, but that's fine!). Testing websocket at some point would be nice, as well as async views (websockets can be synchronous, which is a pattern django channels offers as a concrete solution). But yes, websockets likely would require django channels (not opposed to making it an extra install which is grabbed by the test runner), and that's outside the scope of this code change as that's not truly supported in django at this time (not natively).