### PR TITLE
CI builds install explicit django version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install django==${{ matrix.django-version }}
         python -m pip install -e .
     - name: Run Tests
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - DJANGO="django>=3.1,<3.2"
 
 install:
+    - pip install ${DJANGO}
     - pip install -e .
 
 before_script:


### PR DESCRIPTION
code is fine, just we needed to explicitly install the correct django version (because we're not using requirements or any other binding mechanism).