### PR TITLE
_base_manager instead of objects

### DIFF
--- a/easyaudit/signals/model_signals.py
+++ b/easyaudit/signals/model_signals.py
@@ -68,7 +68,7 @@ def pre_save(sender, instance, raw, using, update_fields, **kwargs):
 
             # created or updated?
             if not created:
-                old_model = sender.objects.get(pk=instance.pk)
+                old_model = sender._base_manager.get(pk=instance.pk)
                 delta = model_delta(old_model, instance)
                 if not delta and getattr(settings, "DJANGO_EASY_AUDIT_CRUD_EVENT_NO_CHANGED_FIELDS_SKIP", False):
                     return False
@@ -79,7 +79,7 @@ def pre_save(sender, instance, raw, using, update_fields, **kwargs):
             try:
                 user = get_current_user()
                 # validate that the user still exists
-                user = get_user_model().objects.get(pk=user.pk)
+                user = get_user_model()._base_manager.get(pk=user.pk)
             except:
                 user = None
 
@@ -93,7 +93,7 @@ def pre_save(sender, instance, raw, using, update_fields, **kwargs):
                 for callback in CRUD_DIFFERENCE_CALLBACKS if callable(callback))
             # create crud event only if all callbacks returned True
             if create_crud_event and not created:
-                c_t = ContentType.objects.get_for_model(instance)
+                c_t = ContentType._base_manager.get_for_model(instance)
 
                 def crud_flow():
                     try:
@@ -145,7 +145,7 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
             try:
                 user = get_current_user()
                 # validate that the user still exists
-                user = get_user_model().objects.get(pk=user.pk)
+                user = get_user_model()._base_manager.get(pk=user.pk)
             except:
                 user = None
 
@@ -161,7 +161,7 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
 
             # create crud event only if all callbacks returned True
             if create_crud_event and created:
-                c_t = ContentType.objects.get_for_model(instance)
+                c_t = ContentType._base_manager.get_for_model(instance)
 
                 def crud_flow():
                     try:
@@ -252,13 +252,13 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
             try:
                 user = get_current_user()
                 # validate that the user still exists
-                user = get_user_model().objects.get(pk=user.pk)
+                user = get_user_model()._base_manager.get(pk=user.pk)
             except:
                 user = None
 
             if isinstance(user, AnonymousUser):
                 user = None
-            c_t = ContentType.objects.get_for_model(instance)
+            c_t = ContentType._base_manager.get_for_model(instance)
 
             def crud_flow():
                 try:
@@ -304,13 +304,13 @@ def post_delete(sender, instance, using, **kwargs):
             try:
                 user = get_current_user()
                 # validate that the user still exists
-                user = get_user_model().objects.get(pk=user.pk)
+                user = get_user_model()._base_manager.get(pk=user.pk)
             except:
                 user = None
 
             if isinstance(user, AnonymousUser):
                 user = None
-            c_t = ContentType.objects.get_for_model(instance)
+            c_t = ContentType._base_manager.get_for_model(instance)
 
             # object id to be used later
             obj_id = instance.pk

--- a/easyaudit/signals/model_signals.py
+++ b/easyaudit/signals/model_signals.py
@@ -93,7 +93,7 @@ def pre_save(sender, instance, raw, using, update_fields, **kwargs):
                 for callback in CRUD_DIFFERENCE_CALLBACKS if callable(callback))
             # create crud event only if all callbacks returned True
             if create_crud_event and not created:
-                c_t = ContentType._base_manager.get_for_model(instance)
+                c_t = ContentType.objects.get_for_model(instance)
 
                 def crud_flow():
                     try:
@@ -161,7 +161,7 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
 
             # create crud event only if all callbacks returned True
             if create_crud_event and created:
-                c_t = ContentType._base_manager.get_for_model(instance)
+                c_t = ContentType.objects.get_for_model(instance)
 
                 def crud_flow():
                     try:
@@ -258,7 +258,7 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
 
             if isinstance(user, AnonymousUser):
                 user = None
-            c_t = ContentType._base_manager.get_for_model(instance)
+            c_t = ContentType.objects.get_for_model(instance)
 
             def crud_flow():
                 try:
@@ -310,7 +310,7 @@ def post_delete(sender, instance, using, **kwargs):
 
             if isinstance(user, AnonymousUser):
                 user = None
-            c_t = ContentType._base_manager.get_for_model(instance)
+            c_t = ContentType.objects.get_for_model(instance)
 
             # object id to be used later
             obj_id = instance.pk


### PR DESCRIPTION
In our project default object managers are overridden in most of the models and we use the django-easy-audit repository in several places, this sometimes creates errors. 
Error scenario:
- We have User model and default object manager overridden for excluding inactive users from queryset.
- Making change any model instance that a deactivated user is connected to triggers easy audit’s pre save signal to audit the change. 
-Easy audit is trying to log the change by creating a CRUDEvent instance but since we exclude inactive users in default object manager and easy audit uses object in their pre save signal, user is not found. 