### PR TITLE
Fix for Issue 175 (possible exception with custom managers hiding som…

### DIFF
--- a/easyaudit/signals/model_signals.py
+++ b/easyaudit/signals/model_signals.py
@@ -68,7 +68,7 @@ def pre_save(sender, instance, raw, using, update_fields, **kwargs):
 
             # created or updated?
             if not created:
-                old_model = sender.objects.get(pk=instance.pk)
+                old_model = sender._default_manager.get(pk=instance.pk)
                 delta = model_delta(old_model, instance)
                 if not delta and getattr(settings, "DJANGO_EASY_AUDIT_CRUD_EVENT_NO_CHANGED_FIELDS_SKIP", False):
                     return False

--- a/easyaudit/tests/test_app/models.py
+++ b/easyaudit/tests/test_app/models.py
@@ -55,3 +55,15 @@ class TestBigIntM2M(models.Model):
     id = models.BigAutoField(primary_key=True)
     name = models.CharField(max_length=50)
     test_m2m = models.ManyToManyField(TestBigIntModel)
+
+class SoftDeleteManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().exclude(deleted=True)
+
+class TestSoftDeleteModel(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    deleted = models.BooleanField(default=False)
+    some_other_field = models.CharField(max_length=50, default='')
+
+    all_objects = models.Manager()
+    objects = SoftDeleteManager()

--- a/easyaudit/tests/test_app/tests.py
+++ b/easyaudit/tests/test_app/tests.py
@@ -18,7 +18,8 @@ import bs4
 from test_app.models import (
     TestModel, TestForeignKey, TestM2M,
     TestBigIntModel, TestBigIntForeignKey, TestBigIntM2M,
-    TestUUIDModel, TestUUIDForeignKey, TestUUIDM2M
+    TestUUIDModel, TestUUIDForeignKey, TestUUIDM2M,
+    TestSoftDeleteModel
 )
 from easyaudit.models import CRUDEvent, RequestEvent
 from easyaudit.middleware.easyaudit import set_current_user, clear_request
@@ -278,3 +279,17 @@ class TestAuditAdmin(TestCase):
         response = self.client.get(reverse('admin:easyaudit_requestevent_changelist'))
         self.assertEqual(200, response.status_code)
         filters = self._list_filters(response.content)
+
+@override_settings(TEST=True)
+class TestCustomManager(TestCase):
+    Model = TestSoftDeleteModel
+
+    def test_soft_delete_model(self):
+        obj = self.Model.objects.create(deleted=True)
+        crud_event_qs = CRUDEvent.objects.filter(object_id=obj.id, content_type=ContentType.objects.get_for_model(obj))
+        self.assertEqual(1, crud_event_qs.count())
+
+        obj.some_other_field = 'this should not fail'
+        obj.save()
+        crud_event_qs = CRUDEvent.objects.filter(object_id=obj.id, content_type=ContentType.objects.get_for_model(obj))
+        self.assertEqual(2, crud_event_qs.count())


### PR DESCRIPTION
As promised - use Django `_default_manager` to prevent exceptions when custom manager excludes certain model instances.