### PR TITLE
Functionality to set user_pk_as_string without a dependency on User fk

### DIFF
--- a/easyaudit/middleware/easyaudit.py
+++ b/easyaudit/middleware/easyaudit.py
@@ -38,7 +38,7 @@ def set_current_user(user):
 
 
 def set_user_pk_as_string(user_pk_string):
-    _thread_locals.user_pk_string = user_pk_string
+    _thread_locals.user_pk_string = str(user_pk_string)
 
 
 def clear_request():

--- a/easyaudit/middleware/easyaudit.py
+++ b/easyaudit/middleware/easyaudit.py
@@ -25,12 +25,20 @@ def get_current_user():
         return getattr(request, 'user', None)
 
 
+def get_user_pk_as_string():
+    return getattr(_thread_locals, 'user_pk_string', None)
+
+
 def set_current_user(user):
     try:
         _thread_locals.request.user = user
     except AttributeError:
         request = MockRequest(user=user)
         _thread_locals.request = request
+
+
+def set_user_pk_as_string(user_pk_string):
+    _thread_locals.user_pk_string = user_pk_string
 
 
 def clear_request():

--- a/easyaudit/signals/model_signals.py
+++ b/easyaudit/signals/model_signals.py
@@ -14,7 +14,7 @@ from django.utils.encoding import force_text
 from django.utils.module_loading import import_string
 
 from easyaudit.middleware.easyaudit import get_current_request, \
-    get_current_user
+    get_current_user, get_user_pk_as_string
 from easyaudit.models import CRUDEvent
 from easyaudit.settings import REGISTERED_CLASSES, UNREGISTERED_CLASSES, \
     WATCH_MODEL_EVENTS, CRUD_DIFFERENCE_CALLBACKS, LOGGING_BACKEND, \
@@ -108,7 +108,7 @@ def pre_save(sender, instance, raw, using, update_fields, **kwargs):
                                 'object_id': instance.pk,
                                 'user_id': getattr(user, 'id', None),
                                 'datetime': timezone.now(),
-                                'user_pk_as_string': str(user.pk) if user else user
+                                'user_pk_as_string': str(user.pk) if user else get_user_pk_as_string() or user
                             })
                     except Exception as e:
                         try:
@@ -174,7 +174,7 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
                                 'object_id': instance.pk,
                                 'user_id': getattr(user, 'id', None),
                                 'datetime': timezone.now(),
-                                'user_pk_as_string': str(user.pk) if user else user
+                                'user_pk_as_string': str(user.pk) if user else get_user_pk_as_string() or user
                             })
                     except Exception as e:
                         try:
@@ -273,7 +273,7 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
                             'object_id': instance.pk,
                             'user_id': getattr(user, 'id', None),
                             'datetime': timezone.now(),
-                            'user_pk_as_string': str(user.pk) if user else user
+                            'user_pk_as_string': str(user.pk) if user else get_user_pk_as_string() or user
                         })
                 except Exception as e:
                     try:
@@ -327,7 +327,7 @@ def post_delete(sender, instance, using, **kwargs):
                             'object_id': obj_id,
                             'user_id': getattr(user, 'id', None),
                             'datetime': timezone.now(),
-                            'user_pk_as_string': str(user.pk) if user else user
+                            'user_pk_as_string': str(user.pk) if user else get_user_pk_as_string() or user
                         })
 
                 except Exception as e:

--- a/easyaudit/tests/test_app/tests.py
+++ b/easyaudit/tests/test_app/tests.py
@@ -2,6 +2,7 @@
 import json
 import re
 from unittest import skip, skipIf
+from uuid import uuid4
 
 import django
 


### PR DESCRIPTION
Implementation to log user information is completely dependent on User fk. This makes it really hard to use this repository for applications that has User model in a different service than the current service.


addresses https://github.com/soynatan/django-easy-audit/issues/177