### PR TITLE
replace smart_text and force_text with smart_str and force_str

### DIFF
--- a/easyaudit/signals/model_signals.py
+++ b/easyaudit/signals/model_signals.py
@@ -10,7 +10,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.db import transaction
 from django.db.models import signals
 from django.utils import timezone
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.module_loading import import_string
 
 from easyaudit.middleware.easyaudit import get_current_request, \
@@ -236,7 +236,7 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
                 related_instances = getattr(instance, m2m_rev_field).all()
                 related_ids = [r.pk for r in related_instances]
 
-                tmp_repr[0]['m2m_rev_model'] = force_text(model._meta)
+                tmp_repr[0]['m2m_rev_model'] = force_str(model._meta)
                 tmp_repr[0]['m2m_rev_pks'] = related_ids
                 tmp_repr[0]['m2m_rev_action'] = action
                 object_json_repr = json.dumps(tmp_repr)

--- a/easyaudit/utils.py
+++ b/easyaudit/utils.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import NOT_PROVIDED, DateTimeField
 from django.utils import timezone
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 
 def get_field_value(obj, field):
@@ -30,7 +30,7 @@ def get_field_value(obj, field):
             value = field.default if field.default is not NOT_PROVIDED else None
     else:
         try:
-            value = smart_text(getattr(obj, field.name, None))
+            value = smart_str(getattr(obj, field.name, None))
         except ObjectDoesNotExist:
             value = field.default if field.default is not NOT_PROVIDED else None
 
@@ -56,8 +56,8 @@ def model_delta(old_model, new_model):
         old_value = get_field_value(old_model, field)
         new_value = get_field_value(new_model, field)
         if old_value != new_value:
-            delta[field.name] = [smart_text(old_value),
-                                 smart_text(new_value)]
+            delta[field.name] = [smart_str(old_value),
+                                 smart_str(new_value)]
 
     if len(delta) == 0:
         delta = None


### PR DESCRIPTION
The _text versions have been deprecated since Django 3.0

https://docs.djangoproject.com/en/3.0/releases/3.0/#django-utils-encoding-force-text-and-smart-text

The _str versions work the same in all Python versions supported by
easyaudit (specifically, in Python 3).

Cleans up many of the deprecation warnings you will see from running
the easyaudit tests with `python -Wa`.