### PR TITLE
Update Django version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "beautifulsoup4",
-        "django>=2.2,<=4.0"
+        "django>=2.2,<5.0"
     ],
     python_requires=">=3.5",
     license='GPL3',


### PR DESCRIPTION
Poetry fails to upgrade Django version with the following error:
```
Because django-easy-audit (1.3.3a1) depends on django (>=2.2,<=4.0)
   and <project-name> depends on Django (^4.0.2), django-easy-audit is forbidden.
  So, because <project-name> depends on django-easy-audit (1.3.3a1), version solving failed.
```