### PR TITLE
Fix EasyAuditModelAdmin.has_delete_permission()

### DIFF
--- a/easyaudit/admin_helpers.py
+++ b/easyaudit/admin_helpers.py
@@ -70,7 +70,7 @@ class EasyAuditModelAdmin(admin.ModelAdmin):
     def has_delete_permission(self, request, obj=None):
         if settings.READONLY_EVENTS:
             return False
-        return True
+        return super().has_delete_permission(request, obj)
 
     def get_urls(self):
         info = self.model._meta.app_label, self.model._meta.model_name


### PR DESCRIPTION
Fix for #190. EasyAuditModelAdmin.has_delete_permission() now respects user permissions if READONLY_EVENTS is False