### PR TITLE
remove default_config for Django versions 3.2+

### DIFF
--- a/easyaudit/__init__.py
+++ b/easyaudit/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = 'easyaudit.apps.EasyAuditConfig'
+import django
+
+if django.VERSION < (3, 2):
+    default_app_config = 'easyaudit.apps.EasyAuditConfig'


### PR DESCRIPTION
Addresses deprecation warning:

> RemovedInDjango41Warning: 'easyaudit' defines default_app_config = 'easyaudit.apps.EasyAuditConfig'.
Django now detects this configuration automatically. You can remove default_app_config.

See: https://docs.djangoproject.com/en/4.0/releases/3.2/#automatic-appconfig-discovery