### PR TITLE
Avoid DB savepoints if no audit is going to be created

### DIFF
--- a/easyaudit/signals/model_signals.py
+++ b/easyaudit/signals/model_signals.py
@@ -54,9 +54,10 @@ def pre_save(sender, instance, raw, using, update_fields, **kwargs):
         return
 
     try:
+        if not should_audit(instance):
+            return False
+
         with transaction.atomic(using=using):
-            if not should_audit(instance):
-                return False
             try:
                 object_json_repr = serializers.serialize("json", [instance])
             except Exception:
@@ -132,9 +133,10 @@ def post_save(sender, instance, created, raw, using, update_fields, **kwargs):
         return
 
     try:
+        if not should_audit(instance):
+            return False
+
         with transaction.atomic(using=using):
-            if not should_audit(instance):
-                return False
             object_json_repr = serializers.serialize("json", [instance])
 
             # created or updated?
@@ -211,13 +213,12 @@ def _m2m_rev_field_name(model1, model2):
 def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwargs):
     """https://docs.djangoproject.com/es/1.10/ref/signals/#m2m-changed"""
     try:
+        if not should_audit(instance):
+            return False
+        if action not in ("post_add", "post_remove", "post_clear"):
+            return False
+
         with transaction.atomic(using=using):
-            if not should_audit(instance):
-                return False
-
-            if action not in ("post_add", "post_remove", "post_clear"):
-                return False
-
             object_json_repr = serializers.serialize("json", [instance])
 
             if reverse:
@@ -301,10 +302,10 @@ def m2m_changed(sender, instance, action, reverse, model, pk_set, using, **kwarg
 def post_delete(sender, instance, using, **kwargs):
     """https://docs.djangoproject.com/es/1.10/ref/signals/#post-delete"""
     try:
-        with transaction.atomic(using=using):
-            if not should_audit(instance):
-                return False
+        if not should_audit(instance):
+            return False
 
+        with transaction.atomic(using=using):
             object_json_repr = serializers.serialize("json", [instance])
 
             # user


### PR DESCRIPTION
If we save a model with a db transaction and that model don't have audit active, it's making unnecessary db calls:
```
SAVEPOINT "xpto_x1";
RELEASE SAVEPOINT "xpto_x1";
```

This happens because django creates a save point if a transaction is open inside another transaction.
To avoid it, and save some db calls, do `should_audit(instance)` before creating `transaction.atomic`.