### PR TITLE
Fix migration 0013 IrreversibleError

### DIFF
--- a/easyaudit/migrations/0013_auto_20190723_0126.py
+++ b/easyaudit/migrations/0013_auto_20190723_0126.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(drop_index_if_exists),
+        migrations.RunPython(drop_index_if_exists, migrations.RunPython.noop),
         migrations.AlterField(
             model_name='requestevent',
             name='url',


### PR DESCRIPTION
Fixes #234 

The RunPython migration action was missing a reverse_code function.
This was set to RunPython.noop, as an index drop can't and shouldn't be reversed.