### PR TITLE
fix: replace timezone.utc with datetime.timezone.utc

### DIFF
--- a/easyaudit/utils.py
+++ b/easyaudit/utils.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from uuid import UUID
+import datetime as dt
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -25,7 +25,7 @@ def get_field_value(obj, field):
         try:
             value = field.to_python(getattr(obj, field.name, None))
             if value is not None and settings.USE_TZ and not timezone.is_naive(value):
-                value = timezone.make_naive(value, timezone=timezone.utc)
+                value = timezone.make_naive(value, timezone=dt.timezone.utc)
         except ObjectDoesNotExist:
             value = field.default if field.default is not NOT_PROVIDED else None
     else:


### PR DESCRIPTION
`timezone.utc` is deprecated and therefore the following `RemovedInDjango50Warning` is emitted during our tests:

```shell
ERROR    easyaudit.signals.model_signals:model_signals.py:125 easy audit had a pre-save exception.
Traceback (most recent call last):
  File "<snip>/.venv/lib/python3.10/site-packages/easyaudit/signals/model_signals.py", line 72, in pre_save
    delta = model_delta(old_model, instance)
  File "<snip>/.venv/lib/python3.10/site-packages/easyaudit/utils.py", line 57, in model_delta
    new_value = get_field_value(new_model, field)
  File "<snip>/.venv/lib/python3.10/site-packages/easyaudit/utils.py", line 28, in get_field_value
    value = timezone.make_naive(value, timezone=timezone.utc)
  File "<snip>/.venv/lib/python3.10/site-packages/django/utils/timezone.py", line 49, in __getattr__
    warnings.warn(
django.utils.deprecation.RemovedInDjango50Warning: The django.utils.timezone.utc alias is deprecated. Please update your code to use datetime.timezone.utc instead.
```

This PR replaces the use of `timezone.utc` with `datetime.timezone.utc`.