### PR TITLE
chore: add Django 5 to test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,10 @@ jobs:
         python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
         django-version: [3.2, 4.1, 4.2]
         exclude:
+          # Django 3.2 only supports Python 3.6 to 3.10
           - python-version: 3.11
+            django-version: 3.2
+          - python-version: 3.12
             django-version: 3.2
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           - python-version: 3.8
             django-version: 5.0
           - python-version: 3.9
-            django-version: 5.0rc1
+            django-version: 5.0
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
-        django-version: [3.2, 4.1, 4.2]
+        django-version: [3.2, 4.1, 4.2, 5.0]
         exclude:
           # Django 3.2 only supports Python 3.6 to 3.10
           - python-version: 3.11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,20 +5,20 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
         django-version: [3.2, 4.1, 4.2]
         exclude:
           - python-version: 3.11
             django-version: 3.2
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
             django-version: 3.2
           # Django 5.0 only supports Python 3.10 to 3.12
           - python-version: 3.8
-            django-version: 5.0rc1
+            django-version: 5.0
           - python-version: 3.9
             django-version: 5.0rc1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
-        django-version: [3.2, 4.1, 4.2, 5.0]
+        django-version: [3.2, 4.1, 4.2, 5.0rc1]
         exclude:
           # Django 3.2 only supports Python 3.6 to 3.10
           - python-version: 3.11
@@ -19,9 +19,9 @@ jobs:
             django-version: 3.2
           # Django 5.0 only supports Python 3.10 to 3.12
           - python-version: 3.8
-            django-version: 5.0
+            django-version: 5.0rc1
           - python-version: 3.9
-            django-version: 5.0
+            django-version: 5.0rc1
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,11 @@ jobs:
             django-version: 3.2
           - python-version: 3.12
             django-version: 3.2
+          # Django 5.0 only supports Python 3.10 to 3.12
+          - python-version: 3.8
+            django-version: 5.0
+          - python-version: 3.9
+            django-version: 5.0
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
-        django-version: [3.2, 4.1, 4.2, 5.0rc1]
+        django-version: [3.2, 4.1, 4.2, '5.0']
         exclude:
           # Django 3.2 only supports Python 3.6 to 3.10
           - python-version: 3.11

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "beautifulsoup4",
-        "django>=2.2,<5.0"
+        "django>=3.2"
     ],
     python_requires=">=3.8",
     license='GPL3',
@@ -27,11 +27,11 @@ setup(
     classifiers=[
         'Environment :: Plugins',
         'Framework :: Django',
-        "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.0",
-        "Framework :: Django :: 3.1",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.1",
+        "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.0",
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: OS Independent',
@@ -41,6 +41,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )


### PR DESCRIPTION
This PR is stacked on top of #264.

Add the release candidate 1 of Django 5.0 to the test matrix.

Also removed the upper version bound (see: https://iscinumpy.dev/post/bound-version-constraints/) to allow users to install this package with higher versions to test and changed the lower version bound to 3.2 (based on the test matrix).