### PR TITLE
Get the edited object like in Django LogEntry() model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ ENV/
 # Rope project settings
 .ropeproject
 .idea
+.DS_Store

--- a/easyaudit/models.py
+++ b/easyaudit/models.py
@@ -52,6 +52,10 @@ class CRUDEvent(models.Model):
 
     def is_delete(self):
         return self.DELETE == self.event_type
+    
+    def get_edited_object(self):
+        """ Return the edited object represented by this CRUD event (Like Django LogEntry does). """
+        return self.content_type.get_object_for_this_type(pk=self.object_id)
 
     class Meta:
         verbose_name = _('CRUD event')


### PR DESCRIPTION
I know it's possible to get the edited object in a python code but hard in templates. So having a method to query/get the edited object directly would be a benefit (easier).

```python
# easy-audit/models.py -> CRUDEvent()
def get_edited_object(self):
    """ Return the edited object represented by this CRUD event (Like Django LogEntry does). """
    return self.content_type.get_object_for_this_type(pk=self.object_id)
```