### PR TITLE
Drop support for Django 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,8 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
-        django-version: [3.2, 4.1, 4.2, '5.0']
+        django-version: [4.2, '5.0']
         exclude:
-          # Django 3.2 only supports Python 3.6 to 3.10
-          - python-version: 3.11
-            django-version: 3.2
-          - python-version: 3.12
-            django-version: 3.2
           # Django 5.0 only supports Python 3.10 to 3.12
           - python-version: 3.8
             django-version: 5.0

--- a/easyaudit/__init__.py
+++ b/easyaudit/__init__.py
@@ -1,4 +1,0 @@
-import django
-
-if django.VERSION < (3, 2):
-    default_app_config = 'easyaudit.apps.EasyAuditConfig'

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ setup(
     classifiers=[
         'Environment :: Plugins',
         'Framework :: Django',
-        "Framework :: Django :: 4.0",
-        "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "beautifulsoup4",
-        "django>=3.2"
+        "django>=4.2"
     ],
     python_requires=">=3.8",
     license='GPL3',
@@ -27,7 +27,6 @@ setup(
     classifiers=[
         'Environment :: Plugins',
         'Framework :: Django',
-        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",


### PR DESCRIPTION
Changes minimum supported version to Django 4.2 in preparation of LTS for Django 3.2 ending in April.

Fixes #269