### PR TITLE
Fix semver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-easy-audit"
-version = "1.3.7.a1"
+version = "1.3.7-a1"
 description = "Yet another Django audit log app, hopefully the simplest one."
 license = "GPL3"
 authors = ["Natán Calzolari <natancalzolari@gmail.com>"]


### PR DESCRIPTION
Semantic versions must be in the form `MAJOR.MINOR.PATCH-PRERELEASE`. The currently applied semver violates the spec.

This is important for CD to function properly. An invalid semver string will cause the job to fail, as it did here: https://github.com/soynatan/django-easy-audit/actions/runs/8333068101/job/22803668383#step:7:9