### PR TITLE
Fix ASGI remote Address handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Below are some of the settings you may want to use. These should be defined in y
   [Check our wiki](https://github.com/soynatan/django-easy-audit/wiki/Settings#request-auditing)
   for more details on how to use it.
 
+- `DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER`
+
+  Defaults to `REMOTE_ADDR`.
+  Set this to an alternate request header such as `HTTP_X_FORWARDED_FOR` when your
+  application is running behind a proxy and you want request events to record that
+  value instead of the direct client address.
+
 - `DJANGO_EASY_AUDIT_CRUD_DIFFERENCE_CALLBACKS`
 
   May point to a list of callables/string-paths-to-functions-classes in which the application code can determine

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -1,4 +1,5 @@
 import re
+from functools import lru_cache
 from importlib import import_module
 
 from django.conf import settings
@@ -20,19 +21,31 @@ from easyaudit.settings import (
 
 session_engine = import_module(settings.SESSION_ENGINE)
 audit_logger = import_string(LOGGING_BACKEND)()
-REGISTERED_URL_PATTERNS = [re.compile(url) for url in REGISTERED_URLS]
-UNREGISTERED_URL_PATTERNS = [re.compile(url) for url in UNREGISTERED_URLS]
+
+
+@lru_cache(maxsize=8)
+def _compile_patterns(urls):
+    return tuple(re.compile(url) for url in urls)
+
+
+def _get_registered_url_patterns():
+    return _compile_patterns(tuple(REGISTERED_URLS))
+
+
+def _get_unregistered_url_patterns():
+    return _compile_patterns(tuple(UNREGISTERED_URLS))
 
 
 def should_log_url(url):
     # check if current url is blacklisted
-    for pattern in UNREGISTERED_URL_PATTERNS:
+    for pattern in _get_unregistered_url_patterns():
         if pattern.match(url):
             return False
 
     # only audit URLs listed in REGISTERED_URLS (if it's set)
-    if REGISTERED_URL_PATTERNS:
-        return any(pattern.match(url) for pattern in REGISTERED_URL_PATTERNS)
+    registered_url_patterns = _get_registered_url_patterns()
+    if registered_url_patterns:
+        return any(pattern.match(url) for pattern in registered_url_patterns)
 
     # all good
     return True
@@ -49,17 +62,24 @@ def _get_asgi_headers(scope):
     }
 
 
+def _normalize_remote_ip(remote_ip):
+    if remote_ip is None:
+        return None
+
+    return remote_ip.split(",", maxsplit=1)[0].strip()
+
+
 def _get_asgi_remote_ip(scope, headers):
     remote_addr_header = _get_remote_addr_header()
     if remote_addr_header != "REMOTE_ADDR":
         asgi_header_name = (
             remote_addr_header.removeprefix("HTTP_").lower().replace("_", "-")
         )
-        remote_ip = headers.get(asgi_header_name)
+        remote_ip = _normalize_remote_ip(headers.get(asgi_header_name))
         if remote_ip:
             return remote_ip
 
-    return next(iter(scope.get("client", ("0.0.0.0", 0))))  # noqa: S104
+    return _normalize_remote_ip(next(iter(scope.get("client", ("0.0.0.0", 0)))))  # noqa: S104
 
 
 def _get_request_details(environ, scope):
@@ -69,7 +89,7 @@ def _get_request_details(environ, scope):
             "method": environ["REQUEST_METHOD"],
             "path": environ["PATH_INFO"],
             "query_string": environ["QUERY_STRING"],
-            "remote_ip": environ.get(_get_remote_addr_header()),
+            "remote_ip": _normalize_remote_ip(environ.get(_get_remote_addr_header())),
         }
 
     headers = _get_asgi_headers(scope)

--- a/easyaudit/signals/request_signals.py
+++ b/easyaudit/signals/request_signals.py
@@ -20,53 +20,71 @@ from easyaudit.settings import (
 
 session_engine = import_module(settings.SESSION_ENGINE)
 audit_logger = import_string(LOGGING_BACKEND)()
+REGISTERED_URL_PATTERNS = [re.compile(url) for url in REGISTERED_URLS]
+UNREGISTERED_URL_PATTERNS = [re.compile(url) for url in UNREGISTERED_URLS]
 
 
 def should_log_url(url):
     # check if current url is blacklisted
-    for unregistered_url in UNREGISTERED_URLS:
-        pattern = re.compile(unregistered_url)
+    for pattern in UNREGISTERED_URL_PATTERNS:
         if pattern.match(url):
             return False
 
     # only audit URLs listed in REGISTERED_URLS (if it's set)
-    if len(REGISTERED_URLS) > 0:
-        for registered_url in REGISTERED_URLS:
-            pattern = re.compile(registered_url)
-            if pattern.match(url):
-                return True
-        return False
+    if REGISTERED_URL_PATTERNS:
+        return any(pattern.match(url) for pattern in REGISTERED_URL_PATTERNS)
 
     # all good
     return True
 
 
-def request_started_handler(sender, **kwargs):
-    environ = kwargs.get("environ")
-    scope = kwargs.get("scope")
+def _get_remote_addr_header():
+    return getattr(settings, "DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER", REMOTE_ADDR_HEADER)
+
+
+def _get_asgi_headers(scope):
+    return {
+        key.decode("latin1").lower(): value.decode("latin1")
+        for key, value in scope.get("headers", [])
+    }
+
+
+def _get_asgi_remote_ip(scope, headers):
+    remote_addr_header = _get_remote_addr_header()
+    if remote_addr_header != "REMOTE_ADDR":
+        asgi_header_name = (
+            remote_addr_header.removeprefix("HTTP_").lower().replace("_", "-")
+        )
+        remote_ip = headers.get(asgi_header_name)
+        if remote_ip:
+            return remote_ip
+
+    return next(iter(scope.get("client", ("0.0.0.0", 0))))  # noqa: S104
+
+
+def _get_request_details(environ, scope):
     if environ:
-        path = environ["PATH_INFO"]
-        cookie_string = environ.get("HTTP_COOKIE")
-        remote_ip = environ.get(REMOTE_ADDR_HEADER, None)
-        method = environ["REQUEST_METHOD"]
-        query_string = environ["QUERY_STRING"]
+        return {
+            "cookie_string": environ.get("HTTP_COOKIE"),
+            "method": environ["REQUEST_METHOD"],
+            "path": environ["PATH_INFO"],
+            "query_string": environ["QUERY_STRING"],
+            "remote_ip": environ.get(_get_remote_addr_header()),
+        }
 
-    else:
-        method = scope.get("method")
-        path = scope.get("path")
-        headers = dict(scope.get("headers"))
-        cookie_string = headers.get(b"cookie")
-        if isinstance(cookie_string, bytes):
-            cookie_string = cookie_string.decode("utf-8")
-        remote_ip = next(iter(scope.get("client", ("0.0.0.0", 0))))  # noqa: S104
-        query_string = scope.get("query_string")
+    headers = _get_asgi_headers(scope)
+    return {
+        "cookie_string": headers.get("cookie"),
+        "method": scope.get("method"),
+        "path": scope.get("path"),
+        "query_string": scope.get("query_string"),
+        "remote_ip": _get_asgi_remote_ip(scope, headers),
+    }
 
-    if not should_log_url(path):
-        return
 
+def _get_user_from_cookie(cookie_string):
     user = None
-    # get the user from cookies
-    if not user and cookie_string:
+    if cookie_string:
         cookie = SimpleCookie()
         cookie.load(cookie_string)
         session_cookie_name = settings.SESSION_COOKIE_NAME
@@ -85,14 +103,28 @@ def request_started_handler(sender, **kwargs):
                 except Exception:
                     user = None
 
+    return user
+
+
+def request_started_handler(sender, **kwargs):
+    request_details = _get_request_details(
+        kwargs.get("environ"),
+        kwargs.get("scope") or {},
+    )
+    path = request_details["path"]
+    if not should_log_url(path):
+        return
+
+    user = _get_user_from_cookie(request_details["cookie_string"])
+
     # may want to wrap this in an atomic transaction later
     audit_logger.request(
         {
             "url": path,
-            "method": method,
-            "query_string": query_string,
+            "method": request_details["method"],
+            "query_string": request_details["query_string"],
             "user_id": getattr(user, "id", None),
-            "remote_ip": remote_ip,
+            "remote_ip": request_details["remote_ip"],
             "datetime": timezone.now(),
         }
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,6 +12,7 @@ from pytest_django.asserts import assertInHTML
 
 from easyaudit.middleware.easyaudit import clear_request, set_current_user
 from easyaudit.models import CRUDEvent, RequestEvent
+from easyaudit.signals.request_signals import should_log_url
 from tests.test_app.models import (
     BigIntForeignKeyModel,
     BigIntM2MModel,
@@ -38,6 +39,12 @@ def test_no_issues(capsys: pytest.CaptureFixture):
 
     captured: str = capsys.readouterr().out
     assert "System check identified no issues" in captured
+
+
+def test_should_log_url_defaults():
+    assert not should_log_url("/admin/easyaudit/requestevent/")
+    assert not should_log_url("/favicon.ico")
+    assert should_log_url("/index")
 
 
 @pytest.mark.parametrize(
@@ -346,6 +353,45 @@ class TestASGIRequestEvent:
         assert event.remote_ip == "127.0.0.1"
 
     async def test_remote_addr_another(self, async_client):
+        assert await RequestEvent.objects.acount() == 0
+
+        resp = await async_client.request(
+            method="GET",
+            path=str(reverse("test_app:index")),
+            server=("127.0.0.1", "80"),
+            client=("10.0.0.1", 111),
+            scheme="http",
+            headers=[(b"host", b"testserver")],
+            query_string="",
+        )
+        assert resp.status_code == 200
+
+        event = await RequestEvent.objects.aget(url=reverse("test_app:index"))
+        assert event.remote_ip == "10.0.0.1"
+
+    async def test_remote_addr_from_configured_header(self, async_client, settings):
+        settings.DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER = "HTTP_X_FORWARDED_FOR"
+        assert await RequestEvent.objects.acount() == 0
+
+        resp = await async_client.request(
+            method="GET",
+            path=str(reverse("test_app:index")),
+            server=("127.0.0.1", "80"),
+            client=("10.0.0.1", 111),
+            scheme="http",
+            headers=[
+                (b"host", b"testserver"),
+                (b"x-forwarded-for", b"203.0.113.9"),
+            ],
+            query_string="",
+        )
+        assert resp.status_code == 200
+
+        event = await RequestEvent.objects.aget(url=reverse("test_app:index"))
+        assert event.remote_ip == "203.0.113.9"
+
+    async def test_remote_addr_falls_back_when_header_missing(self, async_client, settings):
+        settings.DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER = "HTTP_X_FORWARDED_FOR"
         assert await RequestEvent.objects.acount() == 0
 
         resp = await async_client.request(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,6 @@ from pytest_django.asserts import assertInHTML
 
 from easyaudit.middleware.easyaudit import clear_request, set_current_user
 from easyaudit.models import CRUDEvent, RequestEvent
-from easyaudit.signals.request_signals import should_log_url
 from tests.test_app.models import (
     BigIntForeignKeyModel,
     BigIntM2MModel,
@@ -39,12 +38,6 @@ def test_no_issues(capsys: pytest.CaptureFixture):
 
     captured: str = capsys.readouterr().out
     assert "System check identified no issues" in captured
-
-
-def test_should_log_url_defaults():
-    assert not should_log_url("/admin/easyaudit/requestevent/")
-    assert not should_log_url("/favicon.ico")
-    assert should_log_url("/index")
 
 
 @pytest.mark.parametrize(
@@ -381,7 +374,7 @@ class TestASGIRequestEvent:
             scheme="http",
             headers=[
                 (b"host", b"testserver"),
-                (b"x-forwarded-for", b"203.0.113.9"),
+                (b"x-forwarded-for", b"203.0.113.9, 10.0.0.1"),
             ],
             query_string="",
         )
@@ -436,6 +429,26 @@ class TestWSGIRequestEvent:
         assert resp.status_code == 200
 
         assert RequestEvent.objects.get(user=user)
+
+    def test_admin_url_is_not_logged(self, client):
+        assert RequestEvent.objects.count() == 0
+
+        resp = client.get(reverse("admin:index"))
+        assert resp.status_code == 302
+        assert RequestEvent.objects.count() == 0
+
+    def test_remote_addr_from_forwarded_header(self, client, settings):
+        settings.DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER = "HTTP_X_FORWARDED_FOR"
+        assert RequestEvent.objects.count() == 0
+
+        resp = client.get(
+            reverse("test_app:index"),
+            HTTP_X_FORWARDED_FOR="203.0.113.9, 10.0.0.1",
+        )
+        assert resp.status_code == 200
+
+        event = RequestEvent.objects.get(url=reverse("test_app:index"))
+        assert event.remote_ip == "203.0.113.9"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This makes ASGI request logging honor DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER, matching the existing WSGI behavior.

It also cleans up the request signal a bit by precompiling URL regex patterns and splitting the request metadata logic into small helpers.
