### PR TITLE
Fix CRUD logging when object repr fails

### DIFF
--- a/easyaudit/signals/crud_flows.py
+++ b/easyaudit/signals/crud_flows.py
@@ -44,7 +44,7 @@ def log_event(event_type, instance, object_id, object_json_repr, **kwargs):
                 "event_type": event_type,
                 "object_id": object_id,
                 "object_json_repr": object_json_repr or "",
-                "object_repr": str(instance),
+                "object_repr": get_object_repr(instance),
                 "user_id": user_id,
                 "user_pk_as_string": user_pk_as_string,
                 **kwargs,
@@ -126,3 +126,9 @@ def format_primary_key(pk):
     if isinstance(pk, UUID):
         return str(pk)
     return pk
+
+
+def get_object_repr(instance):
+    with contextlib.suppress(Exception):
+        return str(instance)
+    return ""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -191,6 +191,23 @@ class TestAuditModels:
         )
         assert crud_event_qs.count() == 2
 
+    def test_delete_logs_event_when_str_raises(self, model, monkeypatch):
+        obj = model.objects.create()
+        obj_id = obj.pk
+
+        def _raise_str(self):
+            raise ValueError("broken object repr")
+
+        monkeypatch.setattr(model, "__str__", _raise_str)
+        obj.delete()
+
+        crud_event = CRUDEvent.objects.get(
+            object_id=obj_id,
+            content_type=ContentType.objects.get_for_model(obj),
+            event_type=CRUDEvent.DELETE,
+        )
+        assert crud_event.object_repr == ""
+
     @pytest.mark.django_db(transaction=True)
     def test_delete_transaction(self, model, settings):
         settings.TEST = False


### PR DESCRIPTION
## Summary
- keep creating CRUD events when an audited object cannot be stringified
- store an empty object_repr in that edge case instead of dropping the event
- add a regression test for delete events where __str__ raises

Fixes #336.

## Validation
- .venv/bin/python -m pytest tests/test_main.py::TestAuditModels::test_delete_logs_event_when_str_raises tests/test_main.py::TestAuditModels::test_delete tests/test_main.py::TestAuditModels::test_delete_transaction
- .venv/bin/python -m ruff check easyaudit/signals/crud_flows.py tests/test_main.py
- .venv/bin/python -m pytest